### PR TITLE
feat: add Task.runtimeMetadata for host-resolved worker secrets

### DIFF
--- a/src/open-api/__tests__/TaskRuntimeMetadata.test.ts
+++ b/src/open-api/__tests__/TaskRuntimeMetadata.test.ts
@@ -1,0 +1,31 @@
+import { Task } from "../generated/types.gen";
+
+// Compile-time guarantee: the generated Task type carries runtimeMetadata as an optional
+// string->string map. If the OpenAPI spec (and thus the regenerated type) drops the field, this
+// assignment fails `tsc` — the type is the real deliverable for the dynamic TS client.
+const _runtimeMetadataTypeGuard: Record<string, string> | undefined = ({} as Task).runtimeMetadata;
+void _runtimeMetadataTypeGuard;
+
+/**
+ * The server delivers host-resolved secret values on Task.runtimeMetadata (wire-only, never
+ * persisted) when a worker's TaskDef.runtimeMetadata declares secret names (conductor-oss PR #1255).
+ * Verify the generated client type carries the field as a string->string map and round-trips it.
+ */
+describe("Task.runtimeMetadata", () => {
+  it("round-trips host-resolved secret values", () => {
+    const task: Task = {
+      taskId: "t1",
+      runtimeMetadata: { GITHUB_TOKEN: "ghp_secret", GH_APP_ID: "42" },
+    };
+
+    const back = JSON.parse(JSON.stringify(task)) as Task;
+
+    expect(back.runtimeMetadata).toEqual({ GITHUB_TOKEN: "ghp_secret", GH_APP_ID: "42" });
+    expect(back.runtimeMetadata?.["GITHUB_TOKEN"]).toBe("ghp_secret");
+  });
+
+  it("is optional and omitted from the wire when absent", () => {
+    const task: Task = { taskId: "t1" };
+    expect(JSON.stringify(task)).not.toContain("runtimeMetadata");
+  });
+});

--- a/src/open-api/generated/types.gen.ts
+++ b/src/open-api/generated/types.gen.ts
@@ -2188,6 +2188,12 @@ export type Task = {
     outputData?: {
         [key: string]: unknown;
     };
+    /**
+     * Secret values the server resolved for this task at poll time and delivered on the wire only (never persisted). Populated when the task's TaskDef.runtimeMetadata declares secret names the host resolves from its secret store (conductor-oss PR #1255).
+     */
+    runtimeMetadata?: {
+        [key: string]: string;
+    };
     parentTaskId?: string;
     pollCount?: number;
     queueWaitTime?: number;

--- a/src/open-api/spec/spec.json
+++ b/src/open-api/spec/spec.json
@@ -16847,6 +16847,13 @@
               "type": "object",
               "additionalProperties": {}
             },
+            "runtimeMetadata": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Secret values the server resolved for this task at poll time and delivered on the wire only (never persisted). Populated when the task's TaskDef.runtimeMetadata declares secret names the host resolves from its secret store (conductor-oss PR #1255)."
+            },
             "parentTaskId": {
               "type": "string"
             },


### PR DESCRIPTION
## Summary

Adds `runtimeMetadata` to the `Task` schema so the generated client type carries it.

The server can resolve a worker's declared `TaskDef.runtimeMetadata` secret names at poll time and deliver the resolved values on the wire-only `Task.runtimeMetadata` (never persisted to task input). The runtime client already keeps unknown JSON keys; this makes the field first-class and type-checked.

## Changes
- `src/open-api/spec/spec.json`: `Task.runtimeMetadata` (`object`, `additionalProperties: { type: string }`).
- `src/open-api/generated/types.gen.ts`: regenerated via `npm run generate-openapi-layer` → `runtimeMetadata?: { [key: string]: string }`.
- `src/open-api/__tests__/TaskRuntimeMetadata.test.ts`: compile-time type guard + JSON round-trip + omit-when-empty.

## Test
`npx jest --testMatch='**/src/open-api/__tests__/**/*.test.ts'` passes; the type guard was validated fail-first with `tsc` (removing the field yields `TS2339`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)