### PR TITLE
Fix agent examples: top-level await, broken assertion, silent failures

### DIFF
--- a/examples/agents/10-guardrails.ts
+++ b/examples/agents/10-guardrails.ts
@@ -170,11 +170,19 @@ async function main() {
     );
     result.printResult();
 
+    if (result.status !== 'COMPLETED') {
+      console.error(`\nFAIL: agent run ended ${result.status}: ${result.error ?? ''}`);
+      process.exitCode = 1;
+      return;
+    }
+
     // Verify the guardrail worked — no raw card number in the output
-    if (result.output && String(result.output).includes('4532-0150-1234-5678')) {
-    console.log('[WARN] PII leaked through the guardrail!');
+    // (stringify: result.output is an object, String() gives "[object Object]")
+    if (result.output && JSON.stringify(result.output).includes('4532-0150-1234-5678')) {
+      console.log('[WARN] PII leaked through the guardrail!');
+      process.exitCode = 1;
     } else {
-    console.log('[OK] PII was redacted from the final output.');
+      console.log('[OK] PII was redacted from the final output.');
     }
 
     // Production pattern:
@@ -190,4 +198,7 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/12-long-running.ts
+++ b/examples/agents/12-long-running.ts
@@ -24,29 +24,36 @@ export const agent = new Agent({
 
 // Start agent asynchronously (returns immediately)
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(
-    agent,
-    'What are the key metrics to track for a SaaS product?',
-  );
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(
+      agent,
+      'What are the key metrics to track for a SaaS product?',
+    );
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(agent);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents saas_analyst
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(agent);
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(agent);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents saas_analyst
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(agent);
 
-  // Async handle alternative:
-  // const handle = await runtime.start(
-  //   agent,
-  //   'What are the key metrics to track for a SaaS product?',
-  // );
-  // console.log(handle.executionId);
-} finally {
-  await runtime.shutdown();
+    // Async handle alternative:
+    // const handle = await runtime.start(
+    //   agent,
+    //   'What are the key metrics to track for a SaaS product?',
+    // );
+    // console.log(handle.executionId);
+  } finally {
+    await runtime.shutdown();
+  }
 }
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/54-software-bug-assistant.ts
+++ b/examples/agents/54-software-bug-assistant.ts
@@ -277,6 +277,11 @@ async function main() {
     );
     result.printResult();
 
+    if (result.status !== 'COMPLETED') {
+      console.error(`\nFAIL: agent run ended ${result.status}: ${result.error ?? ''}`);
+      process.exitCode = 1;
+    }
+
     // Production pattern:
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(softwareAssistant);
@@ -290,4 +295,7 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/57-plan-dry-run.ts
+++ b/examples/agents/57-plan-dry-run.ts
@@ -64,28 +64,35 @@ export const agent = new Agent({
 
 // -- Plan: compile without executing -----------------------------------------
 
-const runtime = new AgentRuntime();
-try {
-  const workflowDef = (await runtime.plan(agent)) as Record<string, unknown>;
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const workflowDef = (await runtime.plan(agent)) as Record<string, unknown>;
 
-  console.log(`Workflow name: ${workflowDef.name}`);
-  const tasks: Record<string, unknown>[] = (workflowDef.tasks as Record<string, unknown>[]) ?? [];
-  console.log(`Total tasks:   ${tasks.length}`);
-  console.log();
+    console.log(`Workflow name: ${workflowDef.name}`);
+    const tasks: Record<string, unknown>[] = (workflowDef.tasks as Record<string, unknown>[]) ?? [];
+    console.log(`Total tasks:   ${tasks.length}`);
+    console.log();
 
-  // Walk the task tree
-  for (const task of tasks) {
-    console.log(`  [${task.type}] ${task.taskReferenceName}`);
-    if (task.type === 'DO_WHILE' && Array.isArray(task.loopOver)) {
-      for (const sub of task.loopOver as Record<string, unknown>[]) {
-        console.log(`    [${sub.type}] ${sub.taskReferenceName}`);
+    // Walk the task tree
+    for (const task of tasks) {
+      console.log(`  [${task.type}] ${task.taskReferenceName}`);
+      if (task.type === 'DO_WHILE' && Array.isArray(task.loopOver)) {
+        for (const sub of task.loopOver as Record<string, unknown>[]) {
+          console.log(`    [${sub.type}] ${sub.taskReferenceName}`);
+        }
       }
     }
-  }
 
-  // Full JSON for CI/CD validation or export
-  console.log('\n--- Full workflow JSON ---');
-  console.log(JSON.stringify(workflowDef, null, 2));
-} finally {
-  await runtime.shutdown();
+    // Full JSON for CI/CD validation or export
+    console.log('\n--- Full workflow JSON ---');
+    console.log(JSON.stringify(workflowDef, null, 2));
+  } finally {
+    await runtime.shutdown();
+  }
 }
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/63-deploy.ts
+++ b/examples/agents/63-deploy.ts
@@ -70,20 +70,31 @@ export const opsBot = new Agent({
 
 // -- Deploy: compile + register on server ------------------------------------
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(docAssistant, 'How do I reset my password?');
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(docAssistant, 'How do I reset my password?');
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(docAssistant);
-  // await runtime.deploy(opsBot);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(docAssistant, opsBot);
-} finally {
-  await runtime.shutdown();
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(docAssistant);
+    // await runtime.deploy(opsBot);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(docAssistant, opsBot);
+  } finally {
+    await runtime.shutdown();
+  }
+}
+
+// Guard: 63c-run-by-name.ts imports docAssistant from this file — only run
+// when executed directly, not on import.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/examples/agents/63b-serve.ts
+++ b/examples/agents/63b-serve.ts
@@ -74,20 +74,27 @@ export const opsBot = new Agent({
 
 // -- Serve: register workers and block ---------------------------------------
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(opsBot, 'Check the status of the API gateway.');
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(opsBot, 'Check the status of the API gateway.');
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(docAssistant);
-  // await runtime.deploy(opsBot);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(docAssistant, opsBot);
-} finally {
-  await runtime.shutdown();
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(docAssistant);
+    // await runtime.deploy(opsBot);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(docAssistant, opsBot);
+  } finally {
+    await runtime.shutdown();
+  }
 }
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/63c-run-by-name.ts
+++ b/examples/agents/63c-run-by-name.ts
@@ -16,19 +16,26 @@
 import { docAssistant } from './63-deploy.js';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(docAssistant, 'How do I reset my password?');
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(docAssistant, 'How do I reset my password?');
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(docAssistant);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(docAssistant);
-} finally {
-  await runtime.shutdown();
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(docAssistant);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(docAssistant);
+  } finally {
+    await runtime.shutdown();
+  }
 }
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/63d-serve-from-package.ts
+++ b/examples/agents/63d-serve-from-package.ts
@@ -43,19 +43,30 @@ export const monitoringAgent = new Agent({
 
 // -- Serve -------------------------------------------------------------------
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(monitoringAgent, 'Is everything healthy? Run a full check.');
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(monitoringAgent, 'Is everything healthy? Run a full check.');
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(monitoringAgent);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents monitoring
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(monitoringAgent);
-} finally {
-  await runtime.shutdown();
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(monitoringAgent);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents monitoring
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(monitoringAgent);
+  } finally {
+    await runtime.shutdown();
+  }
+}
+
+// Guard: 63e-run-monitoring.ts imports monitoringAgent from this file — only
+// run when executed directly, not on import.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/examples/agents/63e-run-monitoring.ts
+++ b/examples/agents/63e-run-monitoring.ts
@@ -10,19 +10,26 @@
 import { monitoringAgent } from './63d-serve-from-package.js';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
 
-const runtime = new AgentRuntime();
-try {
-  const result = await runtime.run(monitoringAgent, 'Is everything healthy? Run a full check.');
-  result.printResult();
+async function main() {
+  const runtime = new AgentRuntime();
+  try {
+    const result = await runtime.run(monitoringAgent, 'Is everything healthy? Run a full check.');
+    result.printResult();
 
-  // Production pattern:
-  // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
-  // await runtime.deploy(monitoringAgent);
-  // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents monitoring
-  //
-  // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
-  // await runtime.serve(monitoringAgent);
-} finally {
-  await runtime.shutdown();
+    // Production pattern:
+    // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
+    // await runtime.deploy(monitoringAgent);
+    // CLI alternative:
+    // agentspan deploy --package sdk/typescript/examples --agents monitoring
+    //
+    // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
+    // await runtime.serve(monitoringAgent);
+  } finally {
+    await runtime.shutdown();
+  }
 }
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/agents/74-cli-error-output.ts
+++ b/examples/agents/74-cli-error-output.ts
@@ -34,12 +34,16 @@ async function main() {
   try {
     const result = await runtime.run(agent, prompt);
     result.printResult();
-    const output = String(result.output ?? '');
+    // result.output is an object ({ result, finishReason, ... }) — String()
+    // would collapse it to "[object Object]" and the check below would
+    // always fail.
+    const output =
+      typeof result.output === 'string' ? result.output : JSON.stringify(result.output ?? '');
 
     // Verify the agent saw the error output
     const saw = output.includes('No such file or directory') || output.includes('nonexistent');
     if (!saw) {
-      console.error(`\nFAIL: agent did not surface CLI error output. Got: ${String(output)}`);
+      console.error(`\nFAIL: agent did not surface CLI error output. Got: ${output}`);
       process.exit(1);
     }
     console.log('\nPASS: agent correctly reported CLI error output');


### PR DESCRIPTION
## Summary

A full smoke sweep of all 116 `examples/agents/` files against a local Conductor OSS 3.32.0-rc.8 server surfaced three groups of broken examples. This PR fixes the ones that are unambiguously example bugs (SDK/server-level findings are tracked separately).

### 1. Top-level await — examples didn't compile (7 files)

`12-long-running`, `57-plan-dry-run`, `63-deploy`, `63b-serve`, `63c-run-by-name`, `63d-serve-from-package`, `63e-run-monitoring`

Upstream agentspan was ESM; under this repo's CJS module flavor, tsx rejects top-level await, so these examples failed with a `TransformError` before running anything. All are now wrapped in the house-style `async main()`. `63-deploy` and `63d` additionally get a `require.main === module` guard because `63c`/`63e` import their agent definitions — without the guard, importing would execute the sibling example.

### 2. Broken assertion (1 file)

`74-cli-error-output` called `String(result.output)` on an object, always producing `[object Object]`, so its self-check false-failed even though the agent surfaced the CLI stderr correctly. Fixed to stringify properly. The same latent `String(result.output)` bug in `10-guardrails`' PII-leak check is fixed too (it made the leak check vacuous).

### 3. Silent failures — printed `[FAIL]`, exited 0 (2 files)

`10-guardrails` and `54-software-bug-assistant` printed FAILED results but exited 0, so any exit-code-based harness passes vacuously. Both now set exit code 1 when the run ends non-COMPLETED, and their `main().catch` sets the exit code instead of swallowing the error.

## Verification (local Conductor OSS 3.32.0-rc.8 boot JAR, Anthropic Haiku 4.5)

- All 7 top-level-await examples + `74` run green end-to-end (exit 0, `74` prints `PASS`)
- `10` and `54` now exit 1 with the real upstream diagnostics:
  - `10`: server-side `ChatMessage.message` String-vs-Array deserialization error
  - `54`: MCP server rejects credential — "Authorization header is badly formatted"
  (both are SDK/server-level issues, not fixed here)
- `npx tsc --noEmit -p examples/agents/tsconfig.json` clean (one pre-existing, unrelated error in `src/sdk/.../getUndiciHttp2FetchFn.ts`)
- `npx eslint` clean on all 10 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)