### PR TITLE
fix(ci): strip leading v from version input in e2e bundle release workflow

### DIFF
--- a/.github/workflows/release-agent-e2e-bundle.yml
+++ b/.github/workflows/release-agent-e2e-bundle.yml
@@ -37,9 +37,9 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
           else
-            TAG="${{ github.event.release.tag_name }}"
-            VERSION="${TAG#v}"
+            VERSION="${{ github.event.release.tag_name }}"
           fi
+          VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Packaging agent e2e bundle for version: ${VERSION}"
 


### PR DESCRIPTION
Fixes the failure in [run 29867346657](https://github.com/conductor-oss/javascript-sdk/actions/runs/29867346657/job/88758771333): the workflow was manually dispatched with `version: v4.0.0-rc1`, but the `Determine version` step only strips the `v` prefix on the release-event path. The upload step then targeted release `vv4.0.0-rc1`, which doesn't exist (`release not found`).

This normalizes the version by stripping a leading `v` after both branches, so dispatch inputs work with or without the prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)