### PR TITLE
fix(ci) pin mcp below its 2.0.0 API rewrite for the agent-e2e mcp-testkit install

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -87,7 +87,11 @@ jobs:
       - name: Install mcp-testkit
         run: |
           python -m pip install --upgrade pip
-          pip install mcp-testkit
+          # mcp-testkit's own mcp[cli]>=1.0.0 bound is unbounded upward, and
+          # this Python setup is mcp-testkit-only (nothing else here caps mcp
+          # the way google-adk/openai-agents do for python-sdk's e2e install)
+          # -- so pin below mcp 2.0.0's FastMCP -> MCPServer rewrite ourselves.
+          pip install mcp-testkit "mcp<2.0.0"
 
       - name: Start mcp-testkit
         run: |


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- `mcp-testkit`'s own `mcp[cli]>=1.0.0` bound is unbounded upward, and this workflow's Python setup installs nothing else that caps it, so an unpinned install picked up `mcp` 2.0.0 (released 2026-07-28), which removed `mcp.server.fastmcp.FastMCP` — every mcp-testkit process in CI has since crashed on startup, surfacing as `test_suite4`/`test_suite5`'s "not ready on port" timeouts.
- Pin `pip install mcp-testkit "mcp<2.0.0"` in `.github/workflows/agent-e2e.yml` to keep resolving the same `mcp` 1.x line the tests were passing against.

Issue #

Alternatives considered
----

Porting `mcp-testkit` itself to `mcp` 2.0's new `MCPServer` API and releasing a new version — larger, separate change in the `agentspan-ai/mcp-testkit` repo; not needed just to unblock CI.
