### PR TITLE
fix(agents): Custom guardrail worker misreports pass as fail on retry/fix

### DIFF
--- a/examples/agents/04-guardrails.ts
+++ b/examples/agents/04-guardrails.ts
@@ -56,7 +56,7 @@ const factChecker = guardrail(
   {
     name: 'fact_checker',
     position: 'output',
-    onFail: 'human',
+    onFail: 'retry',
   },
 );
 

--- a/src/agents/__tests__/runtime.test.ts
+++ b/src/agents/__tests__/runtime.test.ts
@@ -92,6 +92,7 @@ import {
 } from "../runtime.js";
 import { AgentConfig } from "../config.js";
 import { LivenessMonitor } from "../liveness.js";
+import type { GuardrailDef } from "../types.js";
 import { TokenResource } from "../../open-api/generated";
 
 const mockedGenerateToken = TokenResource.generateToken as jest.MockedFunction<
@@ -882,6 +883,70 @@ describe("AgentRuntime", () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe("_registerGuardrailWorker (custom guardrail on_fail contract)", () => {
+    const baseGDef: GuardrailDef = {
+      name: "fact_checker",
+      position: "output",
+      onFail: "retry",
+      guardrailType: "custom",
+      taskName: "fact_checker",
+      func: undefined,
+    };
+
+    async function registerAndInvoke(
+      gDef: GuardrailDef,
+      inputData: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> {
+      const runtime = new AgentRuntime();
+      let handler: ((inputData: unknown) => Promise<Record<string, unknown>>) | undefined;
+      jest
+        .spyOn((runtime as any).workerManager, "addWorker")
+        .mockImplementation((_taskName: unknown, fn: unknown) => {
+          handler = fn as typeof handler;
+        });
+
+      await (runtime as any)._registerGuardrailWorker(gDef);
+      return handler!(inputData);
+    }
+
+    it("reports on_fail as 'pass' when the guardrail passes, even though onFail is 'retry'", async () => {
+      const result = await registerAndInvoke(
+        { ...baseGDef, func: () => ({ passed: true }) },
+        { content: "clean content" },
+      );
+
+      expect(result).toMatchObject({ passed: true, on_fail: "pass", should_continue: true });
+    });
+
+    it("reports on_fail as the configured value when the guardrail fails", async () => {
+      const result = await registerAndInvoke(
+        { ...baseGDef, func: () => ({ passed: false, message: "Unverifiable claims: always" }) },
+        { content: "This always works." },
+      );
+
+      expect(result).toMatchObject({
+        passed: false,
+        on_fail: "retry",
+        should_continue: false,
+        message: "Unverifiable claims: always",
+      });
+    });
+
+    it("reports on_fail as the configured value when the guardrail function throws", async () => {
+      const result = await registerAndInvoke(
+        {
+          ...baseGDef,
+          func: () => {
+            throw new Error("boom");
+          },
+        },
+        { content: "anything" },
+      );
+
+      expect(result).toMatchObject({ passed: false, on_fail: "retry", should_continue: false });
     });
   });
 });

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1092,13 +1092,14 @@ export class AgentRuntime {
       const content = typeof raw === "object" ? JSON.stringify(raw) : String(raw);
       try {
         const result = await fn(content);
+        const passed = result.passed ?? true;
         return {
-          passed: result.passed ?? true,
+          passed,
           message: result.message ?? "",
-          on_fail: gDef.onFail ?? "raise",
+          on_fail: passed ? "pass" : (gDef.onFail ?? "raise"),
           fixed_output: result.fixedOutput,
           guardrail_name: gDef.name,
-          should_continue: result.passed ?? true,
+          should_continue: passed,
         };
       } catch (err) {
         return {


### PR DESCRIPTION
Pull Request Title: fix(agents): custom guardrail worker misreports pass as fail on retry/fix

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- `_registerGuardrailWorker` always echoed the guardrail's configured `on_fail` value even when the check passed, so the server-side router (which only treats `on_fail: null`/`"pass"` as passing) always routed passing custom guardrails into the retry loop until it hit the retry ceiling and failed the whole run; now sets `on_fail: "pass"` on success, matching Java/Python
- `examples/agents/04-guardrails.ts` used `onFail: 'human'` with the one-shot `runtime.run()` API, which hangs forever since nothing completes the pending human task; changed to `onFail: 'retry'`, matching the same combo demo in `10-guardrails.ts`

Issue #

Alternatives considered
----

None.
