### PR TITLE
test(e2e): accept FAILED for #07 aout_custom_retry, matching its siblings

### DIFF
--- a/e2e/test_suite17_guardrail_matrix.test.ts
+++ b/e2e/test_suite17_guardrail_matrix.test.ts
@@ -728,7 +728,10 @@ const SPECS: Spec[] = [
       ],
     }),
     prompt: "Look up the marker data for item 'test'.",
-    validStatuses: ["COMPLETED"],
+    // retry is model-dependent: the agent may or may not drop MARKER42 within max_retries,
+    // and since conductor-oss/conductor#1365 a retry that exhausts escalates to raise, so the
+    // run legitimately ends FAILED. notContains is still asserted whenever it COMPLETEs.
+    validStatuses: BOTH,
     notContains: "MARKER42",
   },
   {


### PR DESCRIPTION
`Suite 17: Guardrail Matrix` has 27 cases. Their `validStatuses` split:

| value | cases |
|---|---|
| `BOTH` (`COMPLETED`\|`FAILED`) | **19** — every retry and most fix cases |
| `["FAILED"]` | 5 — the `raise` cases |
| `["COMPLETED"]` | **2** — `#07 aout_custom_retry`, `#09 aout_custom_fix` |

`#07` is the outlier. Retry is model-dependent — the agent may or may not drop `MARKER42` within `max_retries` — and since [conductor-oss/conductor#1365](https://github.com/conductor-oss/conductor/pull/1365) a retry that exhausts **escalates to raise** instead of looping to the agent turn cap, so the run legitimately ends `FAILED`. Every other retry case already accepts both (#3, #6, #12, #15, #21, #24).

This doesn't weaken the assertion that matters: `notContains: "MARKER42"` is still checked whenever the run `COMPLETE`s, so a leak still fails.

## Not changed: `#27 tout_custom_fix`

It also fails on server `3.32.0-rc18`, and I've left it strict on purpose.

`#09 aout_custom_fix` keeps `["COMPLETED"]` **and** asserts `contains: "REDACTED"` — and it passes. So agent-output `fix` reliably applies the fix and completes, while tool-output `fix` does not. That asymmetry looks like a defect in the tool-output fix path rather than a flaky assertion, and relaxing `#27` would hide it.

Worth someone with context on `GuardrailCompiler.compileToolGuardrailTasks` confirming whether the custom worker's `fixed_output` reaches the normalize script on the tool path. The script itself is fine — verified directly in GraalJS: `fix` + `fixed_output` stays `fix`, `fix` without it escalates to `raise`, and a passing guardrail is inert.

## How this was found

Running this bundle (`4.0.0-rc1`) against conductor `3.32.0-rc18`: 3 failures, reproduced identically across 4 runs. On `3.32.0-rc.14` the same bundle is green, and #1365 (merged 2026-07-20) postdates the bundle release (2026-07-14). The third failure, `Suite 16 test_guardrail_pass_no_interference`, is also unaddressed here — a *passing* guardrail ends the SSE stream in `error` rather than `done`, which likewise looks server-side.