### PR TITLE
Bump pinned conductor-oss e2e server version to 3.32.0-rc18

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONDUCTOR_OSS_VERSION: "3.32.0-rc.8"  # pinned conductor-oss release — bump deliberately
+  CONDUCTOR_OSS_VERSION: "3.32.0-rc18"  # pinned conductor-oss release — bump deliberately
 
 jobs:
   agent-e2e:


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- Bump `CONDUCTOR_OSS_VERSION` in `.github/workflows/agent-e2e.yml` from `3.32.0-rc.8` to `3.32.0-rc18`.

Alternatives considered
----

_Describe alternative implementation you have considered_