### PR TITLE
fix(agents): wait for a terminal status in getResult()

### DIFF
--- a/src/agents/__tests__/stream.test.ts
+++ b/src/agents/__tests__/stream.test.ts
@@ -324,6 +324,122 @@ describe("AgentStream", () => {
       expect(result.status).toBe("FAILED");
       expect(result.error).toBe("something broke");
     });
+
+    // ── Regression: #155 ───────────────────────────────
+    //
+    // The stream ending does not mean the workflow ended. A single status read
+    // can land while the execution is still RUNNING and report that as the
+    // final answer — e.g. a guardrail that is about to escalate to FAILED.
+
+    it("waits for a non-terminal status to settle before building the result", async () => {
+      const sseChunks = ['event:done\ndata:{"output":{"partial":true}}\n\n'];
+      const statuses = [
+        { status: "RUNNING", output: {} },
+        { status: "RUNNING", output: {} },
+        { status: "FAILED", output: { blocked: true }, reasonForIncompletion: "Do not include secrets." },
+      ];
+
+      let statusCall = 0;
+      global.fetch = jest.fn(async (url: unknown) => {
+        if (String(url).includes("/status")) {
+          const body = statuses[Math.min(statusCall++, statuses.length - 1)];
+          return { ok: true, status: 200, json: async () => body, headers: new Headers() };
+        }
+        return {
+          ok: true,
+          status: 200,
+          body: createSSEStream(sseChunks),
+          text: async () => "",
+          headers: new Headers(),
+        };
+      }) as unknown as typeof fetch;
+
+      const stream = new AgentStream(
+        "http://localhost/sse",
+        async () => ({}),
+        "wf-1",
+        jest.fn(),
+        "http://localhost/api",
+      );
+
+      const result = await stream.getResult();
+
+      // Before the fix this was "RUNNING" — the first read, taken as final.
+      expect(result.status).toBe("FAILED");
+      expect(result.error).toBe("Do not include secrets.");
+      expect(statusCall).toBe(3);
+    });
+
+    it("returns immediately on a terminal status without extra polling", async () => {
+      const sseChunks = ['event:done\ndata:{"output":{}}\n\n'];
+
+      let statusCall = 0;
+      global.fetch = jest.fn(async (url: unknown) => {
+        if (String(url).includes("/status")) {
+          statusCall++;
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "COMPLETED", output: { answer: 42 } }),
+            headers: new Headers(),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          body: createSSEStream(sseChunks),
+          text: async () => "",
+          headers: new Headers(),
+        };
+      }) as unknown as typeof fetch;
+
+      const stream = new AgentStream(
+        "http://localhost/sse",
+        async () => ({}),
+        "wf-1",
+        jest.fn(),
+        "http://localhost/api",
+      );
+
+      const result = await stream.getResult();
+      expect(result.status).toBe("COMPLETED");
+      expect(result.output).toEqual({ answer: 42 });
+      expect(statusCall).toBe(1);
+    });
+
+    it("falls back to stream inference when the status endpoint errors", async () => {
+      const sseChunks = ['event:done\ndata:{"output":{"answer":42}}\n\n'];
+
+      let statusCall = 0;
+      global.fetch = jest.fn(async (url: unknown) => {
+        if (String(url).includes("/status")) {
+          statusCall++;
+          return { ok: false, status: 500, json: async () => ({}), headers: new Headers() };
+        }
+        return {
+          ok: true,
+          status: 200,
+          body: createSSEStream(sseChunks),
+          text: async () => "",
+          headers: new Headers(),
+        };
+      }) as unknown as typeof fetch;
+
+      const stream = new AgentStream(
+        "http://localhost/sse",
+        async () => ({}),
+        "wf-1",
+        jest.fn(),
+        "http://localhost/api",
+      );
+
+      const result = await stream.getResult();
+
+      // An endpoint that is not answering must not burn the settle budget —
+      // give up after one attempt, exactly as before the fix.
+      expect(result.status).toBe("COMPLETED");
+      expect(statusCall).toBe(1);
+    });
   });
 
   describe("executionId", () => {

--- a/src/agents/stream.ts
+++ b/src/agents/stream.ts
@@ -1,13 +1,22 @@
 import type { AgentEvent, AgentResult, AgentStatus } from "./types.js";
 import { stripInternalEventKeys } from "./types.js";
 import { SSETimeoutError, SSEUnavailableError, ConductorAgentError } from "./errors.js";
-import { makeAgentResult } from "./result.js";
+import { makeAgentResult, TERMINAL_STATUSES } from "./result.js";
 
 // ── Constants ───────────────────────────────────────────
 
 const SSE_TIMEOUT_MS = 15_000;
 const MAX_RECONNECT_RETRIES = 5;
 const POLL_INTERVAL_MS = 500;
+/**
+ * How long `getResult()` waits for a non-terminal execution to settle.
+ *
+ * The stream ending does not mean the workflow ended, so the status read can
+ * land mid-flight. This bounds that reconciliation only — it is not a run
+ * timeout, and a still-running execution after this simply reports its last
+ * observed status rather than throwing.
+ */
+const RESULT_SETTLE_TIMEOUT_MS = 30_000;
 
 // ── AgentStream ─────────────────────────────────────────
 
@@ -385,19 +394,12 @@ export class AgentStream implements AsyncIterable<AgentEvent> {
     const errorEvent = this.events.findLast((e) => e.type === "error");
 
     // Poll the server for the real terminal status — the done SSE event
-    // signals stream end, NOT workflow success.
-    let serverStatus: Record<string, unknown> | null = null;
-    if (this.serverUrl && this.executionId) {
-      try {
-        const statusUrl = `${this.serverUrl}/agent/${this.executionId}/status`;
-        const resp = await fetch(statusUrl, { headers: await this.headerProvider() });
-        if (resp.ok) {
-          serverStatus = (await resp.json()) as Record<string, unknown>;
-        }
-      } catch {
-        // Fall back to stream-based inference
-      }
-    }
+    // signals stream end, NOT workflow success. The stream can close before
+    // the workflow's terminal transition, so a single read here can catch the
+    // execution mid-flight and report RUNNING for what is about to be FAILED.
+    // Keep reading until the status is terminal, bounded so a genuinely
+    // long-running execution still returns rather than hanging.
+    const serverStatus = await this._fetchTerminalStatus();
 
     const status =
       (serverStatus?.status as string) ??
@@ -412,6 +414,45 @@ export class AgentStream implements AsyncIterable<AgentEvent> {
       error,
       events: [...this.events],
     });
+  }
+
+  /**
+   * Read the execution status, waiting for it to become terminal.
+   *
+   * Returns as soon as the status is one of {@link TERMINAL_STATUSES}. If the
+   * execution is still non-terminal when the budget expires, returns the last
+   * status seen — callers get the best available answer, never a hang.
+   *
+   * Only a *successful but non-terminal* read is retried. An unreachable or
+   * erroring endpoint returns immediately with whatever was seen last (`null`
+   * on the first attempt, so the caller falls back to stream-based inference)
+   * rather than spending the settle budget on an endpoint that is not
+   * answering — which preserves the previous behaviour on that path.
+   */
+  private async _fetchTerminalStatus(): Promise<Record<string, unknown> | null> {
+    if (!this.serverUrl || !this.executionId) return null;
+
+    const statusUrl = `${this.serverUrl}/agent/${this.executionId}/status`;
+    const deadline = Date.now() + RESULT_SETTLE_TIMEOUT_MS;
+    let last: Record<string, unknown> | null = null;
+
+    for (;;) {
+      let current: Record<string, unknown> | null = null;
+      try {
+        const resp = await fetch(statusUrl, { headers: await this.headerProvider() });
+        if (resp.ok) current = (await resp.json()) as Record<string, unknown>;
+      } catch {
+        // Treated the same as a non-ok response: stop and use what we have.
+      }
+
+      if (!current) return last;
+
+      last = current;
+      if (TERMINAL_STATUSES.has(current.status as string)) return current;
+      if (Date.now() >= deadline) return last;
+
+      await sleep(POLL_INTERVAL_MS);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #155.

## Problem

`AgentRuntime.run()` could return `status: "RUNNING"` for an execution that had already reached a terminal state on the server. Wrong, not late — the failing calls return in **2–4 seconds**, nowhere near any timeout.

`run()` takes its result from the SSE stream, and `AgentStream.getResult()` read the status endpoint **once**. The stream ending does not mean the workflow ended, so that single read can land mid-flight and the non-terminal status becomes the returned result. The comment above it already said *"Poll the server for the real terminal status"* — it just never polled.

It shows up most clearly with guardrails. Server-side the workflow reaches `FAILED` with `reasonForIncompletion` set, after the expected retry iterations and a `TERMINATE` task, and `GET /agent/{id}/status` returns `FAILED`:

```
status: FAILED
reasonForIncompletion: "Do not include secrets."
  1  gr_secrets_loop                    [DO_WHILE]           CANCELED
  …  (3 guardrail retry iterations)
 13  gr_secrets_guardrail_terminate__3  [TERMINATE]          COMPLETED
```

The SDK reported `RUNNING`. A guardrail that worked perfectly looks like it never fired, and callers branching on `result.status` take the wrong branch.

## Change

`getResult()` now reads until the status is terminal, via a new `_fetchTerminalStatus()`:

- Reuses the existing `TERMINAL_STATUSES` set, so this path agrees with `wait()`, `liveness`, and `schedules` rather than inventing its own notion of "done".
- Bounded by `RESULT_SETTLE_TIMEOUT_MS` (30s). On expiry it returns the last status seen rather than throwing — callers get the best available answer, never a hang. This bounds reconciliation only; it is not a run timeout.
- **Only a successful-but-non-terminal read is retried.** An unreachable or erroring endpoint returns immediately with whatever was seen last, which preserves the previous behaviour on that path — a broken endpoint cannot burn the settle budget.

The non-streaming path never had this bug: `_pollForCompletion()` already loops until `isComplete`. That asymmetry between the two paths was the defect, and this closes it.

## Tests

Three regression cases in `src/agents/__tests__/stream.test.ts`:

| case | asserts |
|---|---|
| `RUNNING` → `RUNNING` → `FAILED` | result is `FAILED` with the right `error`; 3 status reads. Returned `RUNNING` before this change. |
| terminal on first read | result is `COMPLETED`; **exactly 1** read — no added latency for the common case |
| status endpoint returns 500 | falls back to stream inference in **1** read — no 30s stall |

`src/agents/__tests__/stream.test.ts` passes 25/25. The settle test takes ~1s of real time, confirming it genuinely polled rather than short-circuiting.

## End-to-end verification

Built the SDK, installed it into the released `conductor-ai-e2e-typescript-4.0.0-rc4` bundle, and ran against a live server with **streaming enabled** and **no server-side change**:

| | stock 4.0.0-rc4 | this branch |
|---|---|---|
| `Suite 8: agent output secrets blocked` | FAIL — `status=RUNNING` | **PASS** |
| `Suite 8: max_retries escalation` | FAIL — `status=RUNNING` | **PASS** |
| `Suite 8: tool input raise — SQL injection blocked` | FAIL (full run) | **PASS** |
| **full Suite 8** | **3 failed / 4 passed** | **7 passed / 7** |

And the **complete 196-test suite**, run twice with identical results, to check for
regressions:

| | stock 4.0.0-rc4 | this branch (2 runs) |
|---|---|---|
| passed | 174 | **178** |
| failed | 8 | **4** |
| remaining failures | guardrails 3, streaming 4, +1 flake | streaming 4 |

Nothing that passed on stock fails on this branch.

### A note on the third guardrail test

`tool input raise — SQL injection blocked` passes when run in isolation but fails in a full
run, so I initially took it for contention and said in #155 that it was *not* part of this
bug. That was wrong — this branch fixes it too, across both full runs.

It is the same race with a different hit rate: under full-suite load the workflow runs longer
relative to stream close, so the single status read lands mid-flight more often. Worth knowing
because it means the bug's visibility scales with load, and a green isolated run is not
evidence that a caller is safe.

## Scope

Draft, and deliberately narrow — it fixes the reported status-reporting race only.

I checked whether it also helps the four `Suite 16` streaming failures on the same setup. **It does not** — they fail identically before and after, so they are a separate problem and are not addressed here.

One pre-existing issue I hit, unrelated to this change: `npm run test:unit` crashes on Node 26 with `ReferenceError: clearTimeout is not defined` in `src/sdk/clients/worker/Poller.ts:76`. It reproduces on a clean checkout of `main`. I ran the `stream.test.ts` suite directly instead. Happy to file it separately.


