### PR TITLE
fix(e2e): widen guardrail matrix polling budget

### DIFF
--- a/e2e/test_suite17_guardrail_matrix.test.ts
+++ b/e2e/test_suite17_guardrail_matrix.test.ts
@@ -22,7 +22,7 @@ import type { GuardrailResult, AgentHandle, AgentStatus } from '@io-orkes/conduc
 import { checkServerHealth, MODEL, getOutputText, expectMsg } from './helpers';
 
 
-jest.setTimeout(600_000); // ported from vitest describe({ timeout }) options
+jest.setTimeout(720_000); // ported from vitest describe({ timeout }) options
 // ── Types ────────────────────────────────────────────────────────────────
 
 interface Spec {
@@ -44,12 +44,12 @@ interface Result {
 
 // ── Constants ────────────────────────────────────────────────────────────
 
-// 8 min overall polling budget. Sits under the 600s beforeAll/describe
+// 10 min overall polling budget. Sits under the 720s beforeAll/describe
 // timeouts while leaving headroom for the per-call LLM retry backoff
 // (retryCount=3, exponential) added to LLM_CHAT_COMPLETE — under 27-way
-// concurrency a transient provider blip can otherwise push a retry workflow
-// past the old 5-min budget and report TIMEOUT.
-const TIMEOUT = 480_000;
+// concurrency a slow provider response can otherwise push a straggler
+// past the old 8-min budget and report TIMEOUT.
+const TIMEOUT = 600_000;
 const BOTH = ["COMPLETED", "FAILED"];
 const RETRY_MAX_TURNS = 4;
 
@@ -1115,7 +1115,7 @@ describe("Suite 17: Guardrail Matrix (3x3x3)", () => {
 
     const completed = Array.from(results.values()).filter((r) => r.status !== "TIMEOUT").length;
     console.log(`\n  ${completed}/27 workflows completed.\n`);
-  }, 600_000);
+  }, 720_000);
 
   afterAll(() => runtime?.shutdown());
 


### PR DESCRIPTION
Pull Request Title: Widen guardrail matrix e2e polling budget

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- bump the guardrail matrix e2e polling budget from 8 to 10 minutes
- same suite has hit this on unrelated branches over the past week, each time on a different one of the 27 sub-tests — a timing budget too tight for LLM latency under concurrency, not a guardrail bug

Alternatives considered
----

- reduce the 27-way concurrency instead of raising the timeout — keeps runtime lower but slows the suite down every run instead of just the rare slow one; raising the budget only costs time when a straggler actually needs it
