### PR TITLE
fix(tasks): forkTaskJoin generates a JOIN with empty joinOn

### DIFF
--- a/src/sdk/builders/tasks/__tests__/factory.test.ts
+++ b/src/sdk/builders/tasks/__tests__/factory.test.ts
@@ -134,10 +134,22 @@ describe("forkTask", () => {
       name: "forkTaskJoin_join",
       taskReferenceName: "forkTaskJoin_join_ref",
       inputParameters: {},
-      joinOn: [],
+      joinOn: ["forkTaskJoin"],
       optional: true,
       type: "JOIN",
     });
+  });
+  it("Should join on the last task of each fork branch", () => {
+    const [, joinTask] = forkTaskJoin("multiStep", [
+      eventTask("first", "prefix", "suffix"),
+      eventTask("second", "prefix", "suffix"),
+      eventTask("last", "prefix", "suffix"),
+    ]);
+    expect(joinTask.joinOn).toEqual(["last"]);
+  });
+  it("Should produce an empty joinOn when there are no fork tasks", () => {
+    const [, joinTask] = forkTaskJoin("emptyFork", []);
+    expect(joinTask.joinOn).toEqual([]);
   });
 });
 

--- a/src/sdk/builders/tasks/forkJoin.ts
+++ b/src/sdk/builders/tasks/forkJoin.ts
@@ -20,7 +20,16 @@ export const forkTaskJoin = (
   taskReferenceName: string,
   forkTasks: TaskDefTypes[],
   optional?: boolean
-): [ForkJoinTaskDef, JoinTaskDef] => [
-  forkTask(taskReferenceName, forkTasks),
-  generateJoinTask({ name: `${taskReferenceName}_join`, optional }),
-];
+): [ForkJoinTaskDef, JoinTaskDef] => {
+  const fork = forkTask(taskReferenceName, forkTasks);
+  // The server checks joinOn with allMatch(), which short-circuits to true on an
+  // empty list — a JOIN with no joinOn completes without waiting for any branch.
+  // Join on the last task of every branch so the JOIN blocks until each finishes.
+  const joinOn = fork.forkTasks
+    .map((branch) => branch[branch.length - 1]?.taskReferenceName)
+    .filter((ref): ref is string => ref !== undefined);
+  return [
+    fork,
+    generateJoinTask({ name: `${taskReferenceName}_join`, joinOn, optional }),
+  ];
+};


### PR DESCRIPTION
Fixes #135.

## Problem

`forkTaskJoin()` builds its JOIN through `generateJoinTask()` without passing `joinOn`, so the generated task carries `joinOn: []`:

```ts
// src/sdk/builders/tasks/forkJoin.ts:19
generateJoinTask({ name: `${taskReferenceName}_join`, optional }),
//                 no joinOn -> generateJoinTask defaults it to []
```

The server evaluates a JOIN with `joinOn.stream().allMatch(...)`, and `allMatch()` short-circuits to `true` on an empty stream. So the JOIN reaches `COMPLETED` the first time it is evaluated, without waiting for any fork branch. The branches keep running, but the workflow moves on past the join, which is the one thing a JOIN exists to prevent.

As reported in #135, against Conductor OSS 3.32.0-rc.9 with a 10s WAIT branch:

```
After 2 seconds:
  forkTaskJoin (joinOn=[])       -> join=COMPLETED    wait_branch=IN_PROGRESS   <- bug
  manual joinOn=['wait_branch']  -> join=IN_PROGRESS  wait_branch=IN_PROGRESS   <- correct
```

## Fix

Derive `joinOn` from the fork branches that were just generated, taking the last task reference of each branch:

```ts
const fork = forkTask(taskReferenceName, forkTasks);
const joinOn = fork.forkTasks
  .map((branch) => branch[branch.length - 1]?.taskReferenceName)
  .filter((ref): ref is string => ref !== undefined);
```

Reading the branches back off the `ForkJoinTaskDef` rather than off the flat `forkTasks` argument means this stays correct if `forkTask()` later emits more than one branch (the multi-branch limitation tracked in #94) - no second fix needed there.

An empty fork task list still yields `joinOn: []`, since there is nothing to wait for.

## Tests

`factory.test.ts` asserted `joinOn: []` and therefore locked in the broken behaviour; it now expects the branch's last task reference. Two cases added: a multi-task branch, and an empty fork task list.

Verified both directions:

- On unfixed source, `Should return a tuple with both fork and join` and `Should join on the last task of each fork branch` **fail** (`Expected ["forkTaskJoin"]`, `Received []`).
- With the fix, the factory suite is **25/25 green**.
- Full unit suite: `npm run test:unit` -> **1568 passed**. The single failure in `src/agents/__tests__/skill.test.ts` (`read_skill_file worker`) reproduces on a clean checkout of `main` and is unrelated to this change.
- `npx eslint` clean on both touched files.

Diff is +26/-5 across two files.