### PR TITLE
docs(examples): GH_TOKEN is required for example 54's GitHub MCP, not optional

### DIFF
--- a/examples/agents/54-software-bug-assistant.ts
+++ b/examples/agents/54-software-bug-assistant.ts
@@ -10,7 +10,7 @@
  *   - Conductor server with AgentTool + MCP support
  *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
  *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
- *   - GH_TOKEN in environment (optional, for GitHub MCP)
+ *   - GH_TOKEN in environment (required for GitHub MCP; e.g. export GH_TOKEN=$(gh auth token))
  */
 
 import { Agent, AgentRuntime, agentTool, tool, mcpTool } from '@io-orkes/conductor-javascript/agents';


### PR DESCRIPTION
One-line doc fix in `examples/agents/54-software-bug-assistant.ts`.

The header comment claimed `GH_TOKEN` is optional, but without it the example builds `Authorization: Bearer ` (empty credential) and the run fails deep inside MCP tool listing with a misleading error:

```
HTTP 400 error from MCP server: bad request: Authorization header is badly formatted
```

The default `api.githubcopilot.com/mcp/` endpoint requires authentication (without the header it returns 401 "missing required Authorization header"), so the token is semantically required — the `?? ''` fallback only converts a missing-config error into a malformed-request error. This documents it as required and shows the quickest way to set it (`export GH_TOKEN=$(gh auth token)`).

No code behavior changes. Verified the example passes end-to-end against conductor-oss 3.32.0-rc18 with a real token (COMPLETED, 11 tool calls incl. live GitHub MCP).

For parity: python-sdk's `54_software_bug_assistant.py` already documents `GH_TOKEN` as a plain requirement.