### PR TITLE
Source conductor version from repo variable

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CONDUCTOR_OSS_VERSION: "3.32.0-rc18"  # pinned conductor-oss release — bump deliberately
+  CONDUCTOR_OSS_VERSION: ${{ vars.CONDUCTOR_SERVER_VERSION || '3.32.1' }}
 
 jobs:
   agent-e2e:


### PR DESCRIPTION
- CONDUCTOR_OSS_VERSION reads vars.CONDUCTOR_SERVER_VERSION
- default bumped to 3.32.1