### PR TITLE
fix(examples): replace retired claude-sonnet-4-20250514 with claude-sonnet-4-6

### DIFF
--- a/examples/agents/56-rag-agent.ts
+++ b/examples/agents/56-rag-agent.ts
@@ -55,7 +55,7 @@ const DOCUMENTS = [
     text:
       "Agent Configuration. Agents are defined with a name, model, instructions, " +
       "and tools. The model field uses the format 'provider/model_name', e.g. " +
-      "'openai/gpt-4o' or 'anthropic/claude-sonnet-4-20250514'. Instructions can be " +
+      "'openai/gpt-4o' or 'anthropic/claude-sonnet-4-6'. Instructions can be " +
       'a string or a PromptTemplate referencing a stored prompt. Tools can be ' +
       '@tool-decorated Python functions, http_tool for REST APIs, mcp_tool for ' +
       'MCP servers, or agent_tool to wrap another agent as a callable tool. ' +

--- a/examples/agents/58-scatter-gather.ts
+++ b/examples/agents/58-scatter-gather.ts
@@ -45,7 +45,7 @@ const searchKnowledgeBase = tool(
 
 export const researcher = new Agent({
   name: 'researcher',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a country analyst. You will be given the name of a country. ' +
     'Use the search_knowledge_base tool ONCE to research that country, then ' +

--- a/examples/agents/59-coding-agent.ts
+++ b/examples/agents/59-coding-agent.ts
@@ -18,7 +18,7 @@ import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
 
 export const qaTester = new Agent({
   name: 'qa_tester',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a meticulous QA engineer. Review the code written by the ' +
     'coder for correctness, edge cases, and bugs. Write and execute test ' +
@@ -36,7 +36,7 @@ export const qaTester = new Agent({
 
 export const coder = new Agent({
   name: 'coder',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are an expert Python developer. Write clean, well-structured ' +
     'Python code to solve the given problem. Always execute your code to ' +

--- a/examples/agents/60-github-coding-agent.ts
+++ b/examples/agents/60-github-coding-agent.ts
@@ -258,7 +258,7 @@ const qaTools = [readFile, listFiles];
 
 export const githubAgent = new Agent({
   name: 'github_agent',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a GitHub operations specialist. You handle all git and GitHub CLI interactions.\n\n' +
     'IMPORTANT: Read the conversation history carefully. If the conversation already contains ' +
@@ -283,7 +283,7 @@ export const githubAgent = new Agent({
 
 export const coderAgent = new Agent({
   name: 'coder',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are an expert developer. Write clean, well-structured code.\n\n' +
     'WHEN YOU RECEIVE A TASK:\n' +
@@ -303,7 +303,7 @@ export const coderAgent = new Agent({
 
 export const qaTester = new Agent({
   name: 'qa_tester',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a meticulous QA engineer. Review the code written by the coder.\n\n' +
     '1. Use read_file to read the code that was written\n' +
@@ -323,7 +323,7 @@ export const qaTester = new Agent({
 
 export const codingTeam = new Agent({
   name: 'coding_team',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a coding team coordinator. Delegate the incoming request ' +
     'to github_agent to get started. Call transfer_to_github_agent now.',

--- a/examples/agents/60a-github-coding-agent-simple.ts
+++ b/examples/agents/60a-github-coding-agent-simple.ts
@@ -21,7 +21,7 @@ const WORK_DIR = `/tmp/codingexamples-${randomBytes(4).toString('hex')}`;
 
 export const githubAgent = new Agent({
   name: 'github_agent',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a GitHub operations specialist.\n\n' +
     `Repo: ${REPO}\nWork dir: ${WORK_DIR}\n\n` +
@@ -45,7 +45,7 @@ export const githubAgent = new Agent({
 
 export const coder = new Agent({
   name: 'coder',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are an expert developer.\n\n' +
     `The repo is cloned at ${WORK_DIR}.\n\n` +
@@ -65,7 +65,7 @@ export const coder = new Agent({
 
 export const qaTester = new Agent({
   name: 'qa_tester',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a meticulous QA engineer.\n\n' +
     `The repo is at ${WORK_DIR}. You can read files with:\n  cat ${WORK_DIR}/src/main.py\n\n` +
@@ -83,7 +83,7 @@ export const qaTester = new Agent({
 
 export const codingTeam = new Agent({
   name: 'coding_team',
-  model: 'anthropic/claude-sonnet-4-20250514',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions:
     'You are a coding team coordinator. Delegate to github_agent. ' +
     'Call transfer_to_github_agent now.',

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -127,7 +127,7 @@ The `CONDUCTOR_AGENT_LLM_MODEL` variable uses the `provider/model-name` format. 
 | Provider | Model string | API key env var |
 |----------|-------------|-----------------|
 | OpenAI | `anthropic/claude-sonnet-4-6` (default) | `OPENAI_API_KEY` |
-| Anthropic | `anthropic/claude-sonnet-4-20250514` | `ANTHROPIC_API_KEY` |
+| Anthropic | `anthropic/claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
 | Google Gemini | `google_gemini/gemini-2.0-flash` | `GOOGLE_GEMINI_API_KEY` |
 | AWS Bedrock | `aws_bedrock/...` | AWS credentials |
 | Azure OpenAI | `azure_openai/...` | Azure credentials |

--- a/examples/agents/adk/35-rag-agent.ts
+++ b/examples/agents/adk/35-rag-agent.ts
@@ -71,7 +71,7 @@ const DOCUMENTS: Document[] = [
     text:
       "Agent Configuration. Agents are defined with a name, model, instructions, " +
       "and tools. The model field uses the format 'provider/model_name', e.g. " +
-      "'openai/gpt-4o' or 'anthropic/claude-sonnet-4-20250514'. Instructions can be " +
+      "'openai/gpt-4o' or 'anthropic/claude-sonnet-4-6'. Instructions can be " +
       'a string or a PromptTemplate referencing a stored prompt. Tools can be ' +
       '@tool-decorated Python functions, http_tool for REST APIs, mcp_tool for ' +
       'MCP servers, or agent_tool to wrap another agent as a callable tool. ' +


### PR DESCRIPTION
Anthropic retired `claude-sonnet-4-20250514` — the API now returns 404 `model not found`, breaking every example pinned to it (58, 59, 60, 60a, plus docstring mentions in 56/adk-35/README).

`claude-sonnet-4-6` is the like-for-like replacement: it still accepts the legacy extended-thinking request shape (`thinking.type: enabled` + `budget_tokens`) that these examples use via `thinkingBudgetTokens`, so they run unchanged on all current server versions. (Claude Sonnet 5 was considered but rejects that legacy shape, which would have required an SDK serialization change as a prerequisite.)

**Verified:** example 59 (extended thinking + code execution) completes end-to-end on `claude-sonnet-4-6` against conductor-oss.