### PR TITLE
docs(examples): migrate agentspan CLI references to the conductor CLI

### DIFF
--- a/examples/agents/01-basic-agent.ts
+++ b/examples/agents/01-basic-agent.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL set as environment variable (optional)
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL set (optional)
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';

--- a/examples/agents/02-tools.ts
+++ b/examples/agents/02-tools.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/02a-simple-tools.ts
+++ b/examples/agents/02a-simple-tools.ts
@@ -9,8 +9,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -71,7 +71,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents weather_stock_agent
+    // conductor deploy --package examples/agents --agents weather_stock_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/02b-multi-step-tools.ts
+++ b/examples/agents/02b-multi-step-tools.ts
@@ -16,8 +16,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -131,7 +131,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents account_analyst
+    // conductor deploy --package examples/agents --agents account_analyst
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/03-multi-agent.ts
+++ b/examples/agents/03-multi-agent.ts
@@ -104,7 +104,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(writingPipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents writer
+    // conductor deploy --package examples/agents --agents writer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(writingPipeline);

--- a/examples/agents/03-structured-output.ts
+++ b/examples/agents/03-structured-output.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -60,7 +60,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents weather_reporter
+    // conductor deploy --package examples/agents --agents weather_reporter
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/04-guardrails.ts
+++ b/examples/agents/04-guardrails.ts
@@ -82,7 +82,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(safeWriter);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents safe_writer
+    // conductor deploy --package examples/agents --agents safe_writer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(safeWriter);

--- a/examples/agents/04-http-and-mcp-tools.ts
+++ b/examples/agents/04-http-and-mcp-tools.ts
@@ -18,14 +18,14 @@
  *   mcp-testkit --transport http --auth <secret>
  *
  *   # Store credentials via CLI or Agentspan UI:
- *   agentspan credentials set HTTP_TEST_API_KEY <secret>
- *   agentspan credentials set MCP_TEST_API_KEY <secret>
+ *   conductor secret put HTTP_TEST_API_KEY <secret>
+ *   conductor secret put MCP_TEST_API_KEY <secret>
  *
  * Requirements:
  *   - Conductor server with LLM support
  *   - mcp-testkit running on http://localhost:3001 (see setup above)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool, httpTool, mcpTool } from '@io-orkes/conductor-javascript/agents';
@@ -103,7 +103,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents http_tools_demo
+    // conductor deploy --package examples/agents --agents http_tools_demo
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/04-mcp-weather.ts
+++ b/examples/agents/04-mcp-weather.ts
@@ -19,13 +19,13 @@
  *   mcp-testkit --transport http --auth <secret>
  *
  *   # Store credentials via CLI or Agentspan UI:
- *   agentspan credentials set MCP_TEST_API_KEY <secret>
+ *   conductor secret put MCP_TEST_API_KEY <secret>
  *
  * Requirements:
  *   - Conductor server with LLM support
  *   - mcp-testkit running on http://localhost:3001 (see setup above)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, mcpTool } from '@io-orkes/conductor-javascript/agents';
@@ -67,7 +67,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents weather_mcp_agent
+    // conductor deploy --package examples/agents --agents weather_mcp_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/05-handoffs.ts
+++ b/examples/agents/05-handoffs.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -113,7 +113,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(support);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents support
+    // conductor deploy --package examples/agents --agents support
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(support);

--- a/examples/agents/05-streaming.ts
+++ b/examples/agents/05-streaming.ts
@@ -29,7 +29,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents streaming_agent
+    // conductor deploy --package examples/agents --agents streaming_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/06-sequential-pipeline.ts
+++ b/examples/agents/06-sequential-pipeline.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -58,7 +58,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents researcher
+    // conductor deploy --package examples/agents --agents researcher
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/07-memory.ts
+++ b/examples/agents/07-memory.ts
@@ -78,7 +78,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(researchAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents research_agent
+    // conductor deploy --package examples/agents --agents research_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(researchAgent);

--- a/examples/agents/07-parallel-agents.ts
+++ b/examples/agents/07-parallel-agents.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -61,7 +61,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(analysis);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents analysis
+    // conductor deploy --package examples/agents --agents analysis
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(analysis);

--- a/examples/agents/08-credentials.ts
+++ b/examples/agents/08-credentials.ts
@@ -108,7 +108,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents credentialed_agent
+    // conductor deploy --package examples/agents --agents credentialed_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/08-router-agent.ts
+++ b/examples/agents/08-router-agent.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -63,7 +63,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(team);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents dev_team
+    // conductor deploy --package examples/agents --agents dev_team
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(team);

--- a/examples/agents/09-human-in-the-loop.ts
+++ b/examples/agents/09-human-in-the-loop.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/09-structured-output.ts
+++ b/examples/agents/09-structured-output.ts
@@ -57,7 +57,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(analyzerAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents article_analyzer
+    // conductor deploy --package examples/agents --agents article_analyzer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(analyzerAgent);

--- a/examples/agents/09b-hitl-with-feedback.ts
+++ b/examples/agents/09b-hitl-with-feedback.ts
@@ -11,8 +11,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/09c-hitl-streaming.ts
+++ b/examples/agents/09c-hitl-streaming.ts
@@ -11,8 +11,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/10-code-execution.ts
+++ b/examples/agents/10-code-execution.ts
@@ -47,7 +47,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(codeAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents code_agent
+    // conductor deploy --package examples/agents --agents code_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(codeAgent);

--- a/examples/agents/10-guardrails.ts
+++ b/examples/agents/10-guardrails.ts
@@ -19,8 +19,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import {
@@ -189,7 +189,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents support_agent
+    // conductor deploy --package examples/agents --agents support_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/11-streaming.ts
+++ b/examples/agents/11-streaming.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, EventTypes } from '@io-orkes/conductor-javascript/agents';
@@ -30,7 +30,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents haiku_writer
+    // conductor deploy --package examples/agents --agents haiku_writer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/12-long-running.ts
+++ b/examples/agents/12-long-running.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -37,7 +37,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents saas_analyst
+    // conductor deploy --package examples/agents --agents saas_analyst
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/13-hierarchical-agents.ts
+++ b/examples/agents/13-hierarchical-agents.ts
@@ -15,8 +15,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, OnTextMention } from '@io-orkes/conductor-javascript/agents';
@@ -114,7 +114,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(ceo);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents ceo
+    // conductor deploy --package examples/agents --agents ceo
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(ceo);

--- a/examples/agents/14-existing-workers.ts
+++ b/examples/agents/14-existing-workers.ts
@@ -15,8 +15,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -149,7 +149,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents customer_support
+    // conductor deploy --package examples/agents --agents customer_support
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/15-agent-discussion.ts
+++ b/examples/agents/15-agent-discussion.ts
@@ -18,8 +18,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -85,7 +85,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents discussion
+    // conductor deploy --package examples/agents --agents discussion
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/16-credentials-isolated-tool.ts
+++ b/examples/agents/16-credentials-isolated-tool.ts
@@ -18,14 +18,14 @@
  *      unchanged.
  *
  * Setup (one-time, via CLI):
- *   agentspan login                                     # authenticate
- *   agentspan credentials set GITHUB_TOKEN <your-github-token> # enter token when prompted
+ *   conductor config save                                 # authenticate
+ *   conductor secret put GITHUB_TOKEN <your-github-token> # enter token when prompted
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL (> 0.4.2, for
  *     runtimeMetadata delivery) or conductor-oss (with PR #1255)
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -152,7 +152,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents github_agent
+    // conductor deploy --package examples/agents --agents github_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16-random-strategy.ts
+++ b/examples/agents/16-random-strategy.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -60,7 +60,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(brainstorm);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents brainstorm
+    // conductor deploy --package examples/agents --agents brainstorm
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(brainstorm);

--- a/examples/agents/16b-credentials-non-isolated.ts
+++ b/examples/agents/16b-credentials-non-isolated.ts
@@ -11,7 +11,7 @@
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - STRIPE_SECRET_KEY stored: agentspan credentials set STRIPE_SECRET_KEY <your-stripe-secret-key>
+ *   - STRIPE_SECRET_KEY stored: conductor secret put STRIPE_SECRET_KEY <your-stripe-secret-key>
  */
 
 import {
@@ -33,7 +33,7 @@ const getCustomerBalance = tool(
     } catch (err) {
       if (err instanceof CredentialNotFoundError) {
         return {
-          error: 'STRIPE_SECRET_KEY not configured -- run: agentspan credentials set STRIPE_SECRET_KEY <your-stripe-secret-key>',
+          error: 'STRIPE_SECRET_KEY not configured -- run: conductor secret put STRIPE_SECRET_KEY <your-stripe-secret-key>',
         };
       }
       throw err;
@@ -155,7 +155,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents billing_agent
+    // conductor deploy --package examples/agents --agents billing_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16c-credentials-cli-tools.ts
+++ b/examples/agents/16c-credentials-cli-tools.ts
@@ -8,10 +8,10 @@
  *   - Multi-credential tools (aws needs multiple env vars)
  *
  * Setup (one-time, via CLI):
- *   agentspan login
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
- *   agentspan credentials set AWS_ACCESS_KEY_ID <your-aws-access-key-id>
- *   agentspan credentials set AWS_SECRET_ACCESS_KEY <your-aws-secret-access-key>
+ *   conductor config save
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
+ *   conductor secret put AWS_ACCESS_KEY_ID <your-aws-access-key-id>
+ *   conductor secret put AWS_SECRET_ACCESS_KEY <your-aws-secret-access-key>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
@@ -178,7 +178,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(githubAwsAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents devops_agent
+    // conductor deploy --package examples/agents --agents devops_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(githubAwsAgent);

--- a/examples/agents/16d-credentials-gh-cli.ts
+++ b/examples/agents/16d-credentials-gh-cli.ts
@@ -7,14 +7,14 @@
  *   - The agent calls `gh` commands directly -- no subprocess boilerplate needed
  *
  * Setup (one-time, via CLI):
- *   agentspan login
- *   agentspan credentials set GH_TOKEN <your-gh-token>
+ *   conductor config save
+ *   conductor secret put GH_TOKEN <your-gh-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
  *   - `gh` CLI installed (https://cli.github.com)
- *   - GH_TOKEN stored via `agentspan credentials set`
+ *   - GH_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -47,7 +47,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents github_cli_agent
+    // conductor deploy --package examples/agents --agents github_cli_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16e-credentials-http-tool.ts
+++ b/examples/agents/16e-credentials-http-tool.ts
@@ -11,12 +11,12 @@
  * in the workflow definition.
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, httpTool } from '@io-orkes/conductor-javascript/agents';
@@ -55,7 +55,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents github_http_agent
+    // conductor deploy --package examples/agents --agents github_http_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16f-credentials-mcp-tool.ts
+++ b/examples/agents/16f-credentials-mcp-tool.ts
@@ -13,7 +13,7 @@
  *   mcp-testkit --transport http --auth <secret>
  *
  *   # Store credentials via CLI or Agentspan UI:
- *   agentspan credentials set MCP_API_KEY <secret>
+ *   conductor secret put MCP_API_KEY <secret>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
@@ -54,7 +54,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents mcp_cred_agent
+    // conductor deploy --package examples/agents --agents mcp_cred_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16g-credentials-framework-passthrough.ts
+++ b/examples/agents/16g-credentials-framework-passthrough.ts
@@ -16,12 +16,12 @@
  * credentials are resolved and injected before tool execution.
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, tool, getCredential } from '@io-orkes/conductor-javascript/agents';
@@ -76,7 +76,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents framework_passthrough_agent
+    // conductor deploy --package examples/agents --agents framework_passthrough_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16h-credentials-external-worker.ts
+++ b/examples/agents/16h-credentials-external-worker.ts
@@ -20,13 +20,13 @@
  * file.
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL (> 0.4.2, for
  *     runtimeMetadata delivery) or conductor-oss (with PR #1255)
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, tool } from '@io-orkes/conductor-javascript/agents';

--- a/examples/agents/16i-credentials-langchain.ts
+++ b/examples/agents/16i-credentials-langchain.ts
@@ -15,12 +15,12 @@
  *   const result = await runtime.run(executor, prompt, { credentials: ["GITHUB_TOKEN"] });
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, tool, getCredential } from '@io-orkes/conductor-javascript/agents';
@@ -73,7 +73,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents langchain_cred_agent
+    // conductor deploy --package examples/agents --agents langchain_cred_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16j-credentials-openai-sdk.ts
+++ b/examples/agents/16j-credentials-openai-sdk.ts
@@ -16,12 +16,12 @@
  *   const result = await runtime.run(openaiAgent, prompt, { credentials: ["GITHUB_TOKEN"] });
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, tool, getCredential } from '@io-orkes/conductor-javascript/agents';
@@ -72,7 +72,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents openai_sdk_cred_agent
+    // conductor deploy --package examples/agents --agents openai_sdk_cred_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/16k-credentials-google-adk.ts
+++ b/examples/agents/16k-credentials-google-adk.ts
@@ -15,12 +15,12 @@
  *   const result = await runtime.run(adkAgent, prompt, { credentials: ["GITHUB_TOKEN"] });
  *
  * Setup (one-time):
- *   agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   conductor secret put GITHUB_TOKEN <your-github-token>
  *
  * Requirements:
  *   - Conductor server running at CONDUCTOR_SERVER_URL
  *   - CONDUCTOR_AGENT_LLM_MODEL set (or defaults to openai/gpt-4o-mini)
- *   - GITHUB_TOKEN stored via `agentspan credentials set`
+ *   - GITHUB_TOKEN stored via `conductor secret put`
  */
 
 import { Agent, AgentRuntime, tool, getCredential } from '@io-orkes/conductor-javascript/agents';
@@ -71,7 +71,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents google_adk_cred_agent
+    // conductor deploy --package examples/agents --agents google_adk_cred_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/17-swarm-orchestration.ts
+++ b/examples/agents/17-swarm-orchestration.ts
@@ -18,8 +18,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, OnTextMention } from '@io-orkes/conductor-javascript/agents';
@@ -81,7 +81,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(support);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents support
+    // conductor deploy --package examples/agents --agents support
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(support);

--- a/examples/agents/18-manual-selection.ts
+++ b/examples/agents/18-manual-selection.ts
@@ -13,8 +13,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/19-composable-termination.ts
+++ b/examples/agents/19-composable-termination.ts
@@ -11,8 +11,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import {
@@ -104,7 +104,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent1);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents researcher
+    // conductor deploy --package examples/agents --agents researcher
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent1);

--- a/examples/agents/20-constrained-transitions.ts
+++ b/examples/agents/20-constrained-transitions.ts
@@ -11,8 +11,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -74,7 +74,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(codeReview);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents code_review
+    // conductor deploy --package examples/agents --agents code_review
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(codeReview);

--- a/examples/agents/21-regex-guardrails.ts
+++ b/examples/agents/21-regex-guardrails.ts
@@ -14,8 +14,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool, RegexGuardrail } from '@io-orkes/conductor-javascript/agents';
@@ -134,7 +134,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents hr_assistant
+    // conductor deploy --package examples/agents --agents hr_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/22-llm-guardrails.ts
+++ b/examples/agents/22-llm-guardrails.ts
@@ -12,8 +12,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, LLMGuardrail } from '@io-orkes/conductor-javascript/agents';
@@ -63,7 +63,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents health_advisor
+    // conductor deploy --package examples/agents --agents health_advisor
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/23-token-tracking.ts
+++ b/examples/agents/23-token-tracking.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -72,7 +72,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents math_tutor
+    // conductor deploy --package examples/agents --agents math_tutor
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/24-code-execution.ts
+++ b/examples/agents/24-code-execution.ts
@@ -12,8 +12,8 @@
  * Requirements:
  *   - Conductor server with LLM support
  *   - Docker (for DockerCodeExecutor example)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import {
@@ -70,7 +70,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents local_coder
+    // conductor deploy --package examples/agents --agents local_coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coder);

--- a/examples/agents/25-semantic-memory.ts
+++ b/examples/agents/25-semantic-memory.ts
@@ -9,8 +9,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import {
@@ -89,7 +89,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents memory_agent
+    // conductor deploy --package examples/agents --agents memory_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/26-opentelemetry-tracing.ts
+++ b/examples/agents/26-opentelemetry-tracing.ts
@@ -14,8 +14,8 @@
  * Requirements:
  *   - npm install @opentelemetry/api @opentelemetry/sdk-trace-base
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool, isTracingEnabled } from '@io-orkes/conductor-javascript/agents';
@@ -72,7 +72,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents traced_agent
+    // conductor deploy --package examples/agents --agents traced_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/28-gpt-assistant-agent.ts
+++ b/examples/agents/28-gpt-assistant-agent.ts
@@ -11,9 +11,9 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - OPENAI_API_KEY=sk-... as environment variable
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - OPENAI_API_KEY=sk-...
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { AgentRuntime, GPTAssistantAgent } from '@io-orkes/conductor-javascript/agents';
@@ -65,7 +65,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(dataAnalyst);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents data_analyst
+    // conductor deploy --package examples/agents --agents data_analyst
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(dataAnalyst);

--- a/examples/agents/29-agent-introductions.ts
+++ b/examples/agents/29-agent-introductions.ts
@@ -10,8 +10,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -82,7 +82,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(designReview);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents design_review
+    // conductor deploy --package examples/agents --agents design_review
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(designReview);

--- a/examples/agents/30-multimodal-agent.ts
+++ b/examples/agents/30-multimodal-agent.ts
@@ -13,8 +13,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support (OpenAI key configured)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -155,7 +155,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(visionAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents vision_analyst
+    // conductor deploy --package examples/agents --agents vision_analyst
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(visionAgent);

--- a/examples/agents/31-tool-guardrails.ts
+++ b/examples/agents/31-tool-guardrails.ts
@@ -9,8 +9,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, guardrail, tool } from '@io-orkes/conductor-javascript/agents';
@@ -91,7 +91,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents db_assistant
+    // conductor deploy --package examples/agents --agents db_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/32-human-guardrail.ts
+++ b/examples/agents/32-human-guardrail.ts
@@ -9,8 +9,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import * as readline from 'node:readline/promises';

--- a/examples/agents/33-external-workers.ts
+++ b/examples/agents/33-external-workers.ts
@@ -15,8 +15,8 @@
  * Requirements:
  *   - Conductor server with LLM support
  *   - The referenced workers must be running somewhere
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -164,7 +164,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(supportAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents support_agent
+    // conductor deploy --package examples/agents --agents support_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(supportAgent);

--- a/examples/agents/33-single-turn-tool.ts
+++ b/examples/agents/33-single-turn-tool.ts
@@ -10,8 +10,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -52,7 +52,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents weather_agent
+    // conductor deploy --package examples/agents --agents weather_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/35-standalone-guardrails.ts
+++ b/examples/agents/35-standalone-guardrails.ts
@@ -13,8 +13,8 @@
  * Requirements:
  *   Part 1 (standalone): none -- no server, no LLM, no workers.
  *   Part 2 (as workers): Conductor server
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { guardrail } from '@io-orkes/conductor-javascript/agents';

--- a/examples/agents/36-simple-agent-guardrails.ts
+++ b/examples/agents/36-simple-agent-guardrails.ts
@@ -15,8 +15,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, RegexGuardrail, guardrail } from '@io-orkes/conductor-javascript/agents';
@@ -97,7 +97,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents essay_writer
+    // conductor deploy --package examples/agents --agents essay_writer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/37-fix-guardrail.ts
+++ b/examples/agents/37-fix-guardrail.ts
@@ -17,8 +17,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, guardrail, tool } from '@io-orkes/conductor-javascript/agents';
@@ -142,7 +142,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents directory_agent
+    // conductor deploy --package examples/agents --agents directory_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/38-tech-trends.ts
+++ b/examples/agents/38-tech-trends.ts
@@ -13,8 +13,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, pdfTool, tool } from '@io-orkes/conductor-javascript/agents';
@@ -357,7 +357,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents hn_researcher
+    // conductor deploy --package examples/agents --agents hn_researcher
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/39-local-code-execution.ts
+++ b/examples/agents/39-local-code-execution.ts
@@ -12,8 +12,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, LocalCodeExecutor } from '@io-orkes/conductor-javascript/agents';
@@ -89,7 +89,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(simpleCoder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents simple_coder
+    // conductor deploy --package examples/agents --agents simple_coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(simpleCoder);

--- a/examples/agents/39a-docker-code-execution.ts
+++ b/examples/agents/39a-docker-code-execution.ts
@@ -8,8 +8,8 @@
  * Requirements:
  *   - Conductor server with LLM support
  *   - Docker installed and daemon running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, DockerCodeExecutor } from '@io-orkes/conductor-javascript/agents';
@@ -47,7 +47,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(dockerCoder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents docker_coder
+    // conductor deploy --package examples/agents --agents docker_coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(dockerCoder);

--- a/examples/agents/39b-jupyter-code-execution.ts
+++ b/examples/agents/39b-jupyter-code-execution.ts
@@ -9,8 +9,8 @@
  * Requirements:
  *   - Conductor server with LLM support
  *   - Jupyter runtime installed (jupyter_client, ipykernel)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, JupyterCodeExecutor } from '@io-orkes/conductor-javascript/agents';
@@ -51,7 +51,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(jupyterCoder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents jupyter_coder
+    // conductor deploy --package examples/agents --agents jupyter_coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(jupyterCoder);

--- a/examples/agents/39c-serverless-code-execution.ts
+++ b/examples/agents/39c-serverless-code-execution.ts
@@ -10,8 +10,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { createServer } from 'http';
@@ -96,7 +96,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(serverlessCoder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents serverless_coder
+    // conductor deploy --package examples/agents --agents serverless_coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(serverlessCoder);

--- a/examples/agents/40-media-generation-agent.ts
+++ b/examples/agents/40-media-generation-agent.ts
@@ -14,8 +14,8 @@
  *
  * Requirements:
  *   - Conductor server with OpenAI integration configured
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, imageTool, audioTool, videoTool } from '@io-orkes/conductor-javascript/agents';
@@ -80,7 +80,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(mediaAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents media_generator
+    // conductor deploy --package examples/agents --agents media_generator
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(mediaAgent);

--- a/examples/agents/41-sequential-pipeline-tools.ts
+++ b/examples/agents/41-sequential-pipeline-tools.ts
@@ -12,8 +12,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -229,7 +229,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents concept_developer
+    // conductor deploy --package examples/agents --agents concept_developer
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/42-security-testing.ts
+++ b/examples/agents/42-security-testing.ts
@@ -16,8 +16,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -152,7 +152,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents red_team_agent
+    // conductor deploy --package examples/agents --agents red_team_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/43-data-security-pipeline.ts
+++ b/examples/agents/43-data-security-pipeline.ts
@@ -15,8 +15,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -140,7 +140,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents data_collector
+    // conductor deploy --package examples/agents --agents data_collector
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/44-safety-guardrails.ts
+++ b/examples/agents/44-safety-guardrails.ts
@@ -16,8 +16,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -139,7 +139,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents helpful_assistant
+    // conductor deploy --package examples/agents --agents helpful_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/45-agent-tool.ts
+++ b/examples/agents/45-agent-tool.ts
@@ -12,8 +12,8 @@
  *
  * Requirements:
  *   - Conductor server with AgentTool support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, agentTool, tool } from '@io-orkes/conductor-javascript/agents';
@@ -118,7 +118,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(manager);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents manager_45
+    // conductor deploy --package examples/agents --agents manager_45
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(manager);

--- a/examples/agents/46-transfer-control.ts
+++ b/examples/agents/46-transfer-control.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -124,7 +124,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coordinator_46
+    // conductor deploy --package examples/agents --agents coordinator_46
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coordinator);

--- a/examples/agents/47-callbacks.ts
+++ b/examples/agents/47-callbacks.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with callback support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, CallbackHandler, tool } from '@io-orkes/conductor-javascript/agents';
@@ -80,7 +80,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents monitored_agent_47
+    // conductor deploy --package examples/agents --agents monitored_agent_47
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/48-planner.ts
+++ b/examples/agents/48-planner.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server with planner support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -93,7 +93,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents research_writer_48
+    // conductor deploy --package examples/agents --agents research_writer_48
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/49-include-contents.ts
+++ b/examples/agents/49-include-contents.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with include_contents support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -78,7 +78,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coordinator_49
+    // conductor deploy --package examples/agents --agents coordinator_49
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coordinator);

--- a/examples/agents/50-thinking-config.ts
+++ b/examples/agents/50-thinking-config.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with thinking config support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -65,7 +65,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents deep_thinker_50
+    // conductor deploy --package examples/agents --agents deep_thinker_50
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/51-shared-state.ts
+++ b/examples/agents/51-shared-state.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with state support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -101,7 +101,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents shopping_assistant_51
+    // conductor deploy --package examples/agents --agents shopping_assistant_51
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/52-nested-strategies.ts
+++ b/examples/agents/52-nested-strategies.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -68,7 +68,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents research_phase_52
+    // conductor deploy --package examples/agents --agents research_phase_52
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/53-agent-lifecycle-callbacks.ts
+++ b/examples/agents/53-agent-lifecycle-callbacks.ts
@@ -7,8 +7,8 @@
  *
  * Requirements:
  *   - Conductor server with callback support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, CallbackHandler, tool } from '@io-orkes/conductor-javascript/agents';
@@ -92,7 +92,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents lifecycle_agent_53
+    // conductor deploy --package examples/agents --agents lifecycle_agent_53
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/54-software-bug-assistant.ts
+++ b/examples/agents/54-software-bug-assistant.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server with AgentTool + MCP support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  *   - GH_TOKEN in environment (required for GitHub MCP; e.g. export GH_TOKEN=$(gh auth token))
  */
 
@@ -286,7 +286,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(softwareAssistant);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents software_assistant_54
+    // conductor deploy --package examples/agents --agents software_assistant_54
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(softwareAssistant);

--- a/examples/agents/55-ml-engineering.ts
+++ b/examples/agents/55-ml-engineering.ts
@@ -11,8 +11,8 @@
  *
  * Requirements:
  *   - Conductor server
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -188,7 +188,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(mlPipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents data_analyst_55
+    // conductor deploy --package examples/agents --agents data_analyst_55
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(mlPipeline);

--- a/examples/agents/56-rag-agent.ts
+++ b/examples/agents/56-rag-agent.ts
@@ -8,8 +8,8 @@
  * Requirements:
  *   - Conductor server with RAG system tasks enabled
  *   - A configured vector database (e.g., pgvector)
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, searchTool, indexTool } from '@io-orkes/conductor-javascript/agents';
@@ -196,7 +196,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(ragAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents rag_assistant
+    // conductor deploy --package examples/agents --agents rag_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(ragAgent);

--- a/examples/agents/57-plan-dry-run.ts
+++ b/examples/agents/57-plan-dry-run.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';

--- a/examples/agents/58-scatter-gather.ts
+++ b/examples/agents/58-scatter-gather.ts
@@ -8,8 +8,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_SECONDARY_LLM_MODEL=openai/gpt-4o as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_SECONDARY_LLM_MODEL=openai/gpt-4o
  */
 
 import { Agent, AgentRuntime, scatterGather, tool } from '@io-orkes/conductor-javascript/agents';
@@ -119,7 +119,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coordinator
+    // conductor deploy --package examples/agents --agents coordinator
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coordinator);

--- a/examples/agents/59-coding-agent.ts
+++ b/examples/agents/59-coding-agent.ts
@@ -9,7 +9,7 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -88,7 +88,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coder);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coder
+    // conductor deploy --package examples/agents --agents coder
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coder);

--- a/examples/agents/60-github-coding-agent.ts
+++ b/examples/agents/60-github-coding-agent.ts
@@ -9,7 +9,7 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  *   - gh CLI authenticated
  *   - Git configured with push access to the repo
  */
@@ -383,7 +383,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(codingTeam);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coding_team
+    // conductor deploy --package examples/agents --agents coding_team
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(codingTeam);

--- a/examples/agents/60a-github-coding-agent-simple.ts
+++ b/examples/agents/60a-github-coding-agent-simple.ts
@@ -6,7 +6,7 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  *   - gh CLI authenticated
  *   - Git configured with push access to the repo
  */
@@ -144,7 +144,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(codingTeam);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coding_team
+    // conductor deploy --package examples/agents --agents coding_team
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(codingTeam);

--- a/examples/agents/61-github-coding-agent-chained.ts
+++ b/examples/agents/61-github-coding-agent-chained.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - GITHUB_TOKEN stored: agentspan credentials set GITHUB_TOKEN <your-github-token>
+ *   - GITHUB_TOKEN stored: conductor secret put GITHUB_TOKEN <your-github-token>
  *   - gh CLI installed
  */
 
@@ -148,7 +148,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents git_fetch_issues
+    // conductor deploy --package examples/agents --agents git_fetch_issues
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(pipeline);

--- a/examples/agents/62-cli-tool-guardrails.ts
+++ b/examples/agents/62-cli-tool-guardrails.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, RegexGuardrail } from '@io-orkes/conductor-javascript/agents';
@@ -77,7 +77,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(opsAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents ops_agent
+    // conductor deploy --package examples/agents --agents ops_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(opsAgent);

--- a/examples/agents/63-deploy.ts
+++ b/examples/agents/63-deploy.ts
@@ -9,8 +9,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -81,7 +81,7 @@ async function main() {
     // await runtime.deploy(docAssistant);
     // await runtime.deploy(opsBot);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
+    // conductor deploy --package examples/agents --agents doc_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(docAssistant, opsBot);

--- a/examples/agents/63b-serve.ts
+++ b/examples/agents/63b-serve.ts
@@ -13,8 +13,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -85,7 +85,7 @@ async function main() {
     // await runtime.deploy(docAssistant);
     // await runtime.deploy(opsBot);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents doc_assistant
+    // conductor deploy --package examples/agents --agents doc_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(docAssistant, opsBot);

--- a/examples/agents/63d-serve-from-package.ts
+++ b/examples/agents/63d-serve-from-package.ts
@@ -10,8 +10,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -53,7 +53,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(monitoringAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents monitoring
+    // conductor deploy --package examples/agents --agents monitoring
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(monitoringAgent);

--- a/examples/agents/64-swarm-with-tools.ts
+++ b/examples/agents/64-swarm-with-tools.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, OnTextMention, tool } from '@io-orkes/conductor-javascript/agents';
@@ -124,7 +124,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(support);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents support
+    // conductor deploy --package examples/agents --agents support
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(support);

--- a/examples/agents/65-parallel-with-tools.ts
+++ b/examples/agents/65-parallel-with-tools.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, tool } from '@io-orkes/conductor-javascript/agents';
@@ -108,7 +108,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(analysis);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents parallel_analysis
+    // conductor deploy --package examples/agents --agents parallel_analysis
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(analysis);

--- a/examples/agents/66-handoff-to-parallel.ts
+++ b/examples/agents/66-handoff-to-parallel.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -100,7 +100,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents coordinator_66
+    // conductor deploy --package examples/agents --agents coordinator_66
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(coordinator);

--- a/examples/agents/67-router-to-sequential.ts
+++ b/examples/agents/67-router-to-sequential.ts
@@ -6,8 +6,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
@@ -108,7 +108,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(team);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents team_67
+    // conductor deploy --package examples/agents --agents team_67
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(team);

--- a/examples/agents/68-context-condensation.ts
+++ b/examples/agents/68-context-condensation.ts
@@ -10,8 +10,8 @@
  *
  * Requirements:
  *   - Conductor server with LLM support + agentspan.default-context-window=10000
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, agentTool, tool } from '@io-orkes/conductor-javascript/agents';
@@ -188,7 +188,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(orchestrator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents research_orchestrator_68
+    // conductor deploy --package examples/agents --agents research_orchestrator_68
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(orchestrator);

--- a/examples/agents/70-ce-support-agent.ts
+++ b/examples/agents/70-ce-support-agent.ts
@@ -5,7 +5,7 @@
  * HubSpot, Notion (runbooks), and GitHub to produce a solution with a
  * priority rating.
  *
- * Required credentials (set via `agentspan credentials set`):
+ * Required credentials (set via `conductor secret put`):
  *   ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_API_TOKEN
  *   JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN
  *   HUBSPOT_ACCESS_TOKEN
@@ -14,8 +14,8 @@
  *
  * Requirements:
  *   - Conductor server
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import { Agent, AgentRuntime, RegexGuardrail, agentTool, tool } from '@io-orkes/conductor-javascript/agents';
@@ -374,7 +374,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(ceSupportAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents ce_support_agent
+    // conductor deploy --package examples/agents --agents ce_support_agent
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(ceSupportAgent);

--- a/examples/agents/71-api-tool.ts
+++ b/examples/agents/71-api-tool.ts
@@ -20,14 +20,14 @@
  *   mcp-testkit --transport http --auth <secret>
  *
  *   # Store credentials via CLI or Agentspan UI:
- *   agentspan credentials set HTTP_TEST_API_KEY <secret>
+ *   conductor secret put HTTP_TEST_API_KEY <secret>
  *
  * Requirements:
  *   - Conductor server with LLM support
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  *   - mcp-testkit running on http://localhost:3001 (for examples 1-3, see setup above)
- *   - For GitHub example: agentspan credentials set GITHUB_TOKEN ghp_xxx
+ *   - For GitHub example: conductor secret put GITHUB_TOKEN ghp_xxx
  */
 
 import { Agent, AgentRuntime, apiTool, tool } from '@io-orkes/conductor-javascript/agents';
@@ -170,7 +170,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(mathAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents math_assistant
+    // conductor deploy --package examples/agents --agents math_assistant
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(mathAgent);

--- a/examples/agents/74-cli-error-output.ts
+++ b/examples/agents/74-cli-error-output.ts
@@ -52,7 +52,7 @@ async function main() {
     // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples --agents cli_error_tester
+    // conductor deploy --package examples/agents --agents cli_error_tester
     //
     // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
     // await runtime.serve(agent);

--- a/examples/agents/90-guardrail-e2e-tests.ts
+++ b/examples/agents/90-guardrail-e2e-tests.ts
@@ -5,8 +5,8 @@
  *
  * Requirements:
  *   - Conductor server running
- *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api as environment variable
- *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini as environment variable
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
+ *   - CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
  */
 
 import {

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -26,7 +26,7 @@ In production, the three concerns are separated:
 │     Registers the agent definition with the Conductor server │
 │                                                              │
 │     await runtime.deploy(agent);                             │
-│     // or CLI: agentspan deploy --package my-agents          │
+│     // or CLI: conductor deploy --package my-agents          │
 ├──────────────────────────────────────────────────────────────┤
 │  2. SERVE (long-running worker process)                      │
 │     Listens for tool-call tasks and executes them            │
@@ -37,7 +37,7 @@ In production, the three concerns are separated:
 │  3. RUN (on-demand, from anywhere)                           │
 │     Triggers an agent execution                              │
 │                                                              │
-│     agentspan run <agent-name> "prompt"                      │
+│     conductor agent run --name <agent-name> "prompt"         │
 │     // or SDK: await runtime.run("agent_name", "prompt");    │
 │     // or REST API                                           │
 └──────────────────────────────────────────────────────────────┘

--- a/examples/agents/adk/00-hello-world.ts
+++ b/examples/agents/adk/00-hello-world.ts
@@ -6,7 +6,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -20,7 +20,7 @@ export const agent = new LlmAgent({
   instruction: 'You are a friendly greeter. Reply with a warm hello and one fun fact.',
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -33,7 +33,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents greeter
+    // conductor deploy --package examples/agents/adk --agents greeter
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/01-basic-agent.ts
+++ b/examples/agents/adk/01-basic-agent.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -22,7 +22,7 @@ export const agent = new LlmAgent({
   instruction: 'You are a friendly assistant. Keep your responses concise and helpful.',
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -38,7 +38,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents greeter
+    // conductor deploy --package examples/agents/adk --agents greeter
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/02-function-tools.ts
+++ b/examples/agents/adk/02-function-tools.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -85,7 +85,7 @@ export const agent = new LlmAgent({
   tools: [getWeather, convertTemperature, getTimeZone],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -102,7 +102,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents travel_assistant
+    // conductor deploy --package examples/agents/adk --agents travel_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/03-structured-output.ts
+++ b/examples/agents/adk/03-structured-output.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, zodObjectToSchema } from '@google/adk';
@@ -56,7 +56,7 @@ export const agent = new LlmAgent({
   },
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -72,7 +72,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents recipe_generator
+    // conductor deploy --package examples/agents/adk --agents recipe_generator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/04-sub-agents.ts
+++ b/examples/agents/adk/04-sub-agents.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -118,7 +118,7 @@ export const coordinator = new LlmAgent({
   subAgents: [flightAgent, hotelAgent, advisoryAgent],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -135,7 +135,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents travel_coordinator
+    // conductor deploy --package examples/agents/adk --agents travel_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/05-generation-config.ts
+++ b/examples/agents/adk/05-generation-config.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -42,7 +42,7 @@ export const creativeAgent = new LlmAgent({
   },
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -64,7 +64,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(factualAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents fact_checker
+    // conductor deploy --package examples/agents/adk --agents fact_checker
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(factualAgent);

--- a/examples/agents/adk/06-streaming.ts
+++ b/examples/agents/adk/06-streaming.ts
@@ -3,11 +3,11 @@
  *
  * Demonstrates:
  *   - Streaming events from a Google ADK agent
- *   - Agentspan path: runtime.stream() with event types
+ *   - Conductor path: runtime.stream() with event types
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -59,7 +59,7 @@ export const agent = new LlmAgent({
   tools: [searchDocumentation],
 });
 
-// ── Run on agentspan (streaming) ───────────────────────────────────
+// ── Run on Conductor (streaming) ───────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -71,7 +71,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents docs_assistant
+    // conductor deploy --package examples/agents/adk --agents docs_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/07-output-key-state.ts
+++ b/examples/agents/adk/07-output-key-state.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -94,7 +94,7 @@ export const coordinator = new LlmAgent({
   subAgents: [analyst, visualizer],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -110,7 +110,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents report_coordinator
+    // conductor deploy --package examples/agents/adk --agents report_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/08-instruction-templating.ts
+++ b/examples/agents/adk/08-instruction-templating.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -86,7 +86,7 @@ export const agent = new LlmAgent({
   tools: [getUserPreferences, searchTutorials],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -102,7 +102,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents adaptive_tutor
+    // conductor deploy --package examples/agents/adk --agents adaptive_tutor
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/09-multi-tool-agent.ts
+++ b/examples/agents/adk/09-multi-tool-agent.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -138,7 +138,7 @@ export const agent = new LlmAgent({
   tools: [searchProducts, checkInventory, calculateShipping, applyCoupon],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -155,7 +155,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents shopping_assistant
+    // conductor deploy --package examples/agents/adk --agents shopping_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/10-hierarchical-agents.ts
+++ b/examples/agents/adk/10-hierarchical-agents.ts
@@ -9,7 +9,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -148,7 +148,7 @@ export const coordinator = new LlmAgent({
   subAgents: [reliabilityLead, securityLead],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -165,7 +165,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents platform_coordinator
+    // conductor deploy --package examples/agents/adk --agents platform_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/11-sequential-agent.ts
+++ b/examples/agents/adk/11-sequential-agent.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent } from '@google/adk';
@@ -50,7 +50,7 @@ export const pipeline = new SequentialAgent({
   subAgents: [researcher, writer, editor],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -63,7 +63,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents content_pipeline
+    // conductor deploy --package examples/agents/adk --agents content_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(pipeline);

--- a/examples/agents/adk/12-parallel-agent.ts
+++ b/examples/agents/adk/12-parallel-agent.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, ParallelAgent } from '@google/adk';
@@ -50,7 +50,7 @@ export const parallelAnalysis = new ParallelAgent({
   subAgents: [marketAnalyst, techAnalyst, riskAnalyst],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -66,7 +66,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(parallelAnalysis);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents parallel_analysis
+    // conductor deploy --package examples/agents/adk --agents parallel_analysis
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(parallelAnalysis);

--- a/examples/agents/adk/13-loop-agent.ts
+++ b/examples/agents/adk/13-loop-agent.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, LoopAgent } from '@google/adk';
@@ -50,7 +50,7 @@ export const refinementLoop = new LoopAgent({
   maxIterations: 3,
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -66,7 +66,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(refinementLoop);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents refinement_loop
+    // conductor deploy --package examples/agents/adk --agents refinement_loop
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(refinementLoop);

--- a/examples/agents/adk/14-callbacks.ts
+++ b/examples/agents/adk/14-callbacks.ts
@@ -12,7 +12,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -105,7 +105,7 @@ export const agent = new LlmAgent({
   },
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -122,7 +122,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents customer_service_agent
+    // conductor deploy --package examples/agents/adk --agents customer_service_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/15-global-instruction.ts
+++ b/examples/agents/adk/15-global-instruction.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -84,7 +84,7 @@ export const agent = new LlmAgent({
   tools: [getProductInfo, getStoreHours],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -100,7 +100,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents store_assistant
+    // conductor deploy --package examples/agents/adk --agents store_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/16-customer-service.ts
+++ b/examples/agents/adk/16-customer-service.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -126,7 +126,7 @@ export const agent = new LlmAgent({
   tools: [getAccountDetails, getBillingHistory, submitSupportTicket, updateAccountPlan],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -143,7 +143,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents customer_service_rep
+    // conductor deploy --package examples/agents/adk --agents customer_service_rep
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/17-financial-advisor.ts
+++ b/examples/agents/adk/17-financial-advisor.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -162,7 +162,7 @@ export const coordinator = new LlmAgent({
   subAgents: [portfolioAnalyst, marketResearcher, taxAdvisor],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -179,7 +179,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents financial_advisor
+    // conductor deploy --package examples/agents/adk --agents financial_advisor
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/18-order-processing.ts
+++ b/examples/agents/adk/18-order-processing.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -128,7 +128,7 @@ export const agent = new LlmAgent({
   tools: [searchCatalog, checkStock, calculateTotal, placeOrder],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -145,7 +145,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents order_processor
+    // conductor deploy --package examples/agents/adk --agents order_processor
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/19-supply-chain.ts
+++ b/examples/agents/adk/19-supply-chain.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -163,7 +163,7 @@ export const coordinator = new LlmAgent({
   subAgents: [inventoryAgent, logisticsAgent, demandAgent],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -180,7 +180,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents supply_chain_coordinator
+    // conductor deploy --package examples/agents/adk --agents supply_chain_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/20-blog-writer.ts
+++ b/examples/agents/adk/20-blog-writer.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -123,7 +123,7 @@ export const coordinator = new LlmAgent({
   subAgents: [researcher, writer, editor],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -140,7 +140,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents content_coordinator
+    // conductor deploy --package examples/agents/adk --agents content_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/21-agent-tool.ts
+++ b/examples/agents/adk/21-agent-tool.ts
@@ -15,7 +15,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool, AgentTool } from '@google/adk';
@@ -123,7 +123,7 @@ export const manager = new LlmAgent({
   ],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -140,7 +140,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(manager);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents manager
+    // conductor deploy --package examples/agents/adk --agents manager
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(manager);

--- a/examples/agents/adk/22-transfer-control.ts
+++ b/examples/agents/adk/22-transfer-control.ts
@@ -15,7 +15,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -67,7 +67,7 @@ export const coordinator = new LlmAgent({
   subAgents: [specialistA, specialistB, specialistC],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -83,7 +83,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents research_coordinator
+    // conductor deploy --package examples/agents/adk --agents research_coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/23-callbacks-advanced.ts
+++ b/examples/agents/adk/23-callbacks-advanced.ts
@@ -8,7 +8,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -57,7 +57,7 @@ export const agent = new LlmAgent({
   afterModelCallback: inspectAfterModel,
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -73,7 +73,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents monitored_assistant
+    // conductor deploy --package examples/agents/adk --agents monitored_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/24-planner.ts
+++ b/examples/agents/adk/24-planner.ts
@@ -12,7 +12,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -86,7 +86,7 @@ export const agent = new LlmAgent({
   },
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -103,7 +103,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents research_writer
+    // conductor deploy --package examples/agents/adk --agents research_writer
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/25-camel-security.ts
+++ b/examples/agents/adk/25-camel-security.ts
@@ -11,7 +11,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, FunctionTool } from '@google/adk';
@@ -114,7 +114,7 @@ export const pipeline = new SequentialAgent({
   subAgents: [collector, validator, responder],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -130,7 +130,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents secure_data_pipeline
+    // conductor deploy --package examples/agents/adk --agents secure_data_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(pipeline);

--- a/examples/agents/adk/26-safety-guardrails.ts
+++ b/examples/agents/adk/26-safety-guardrails.ts
@@ -11,7 +11,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, FunctionTool } from '@google/adk';
@@ -106,7 +106,7 @@ export const safePipeline = new SequentialAgent({
   subAgents: [assistant, safetyChecker],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -123,7 +123,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(safePipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents safe_assistant
+    // conductor deploy --package examples/agents/adk --agents safe_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(safePipeline);

--- a/examples/agents/adk/27-security-agent.ts
+++ b/examples/agents/adk/27-security-agent.ts
@@ -13,7 +13,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, FunctionTool } from '@google/adk';
@@ -124,7 +124,7 @@ export const securityTest = new SequentialAgent({
   subAgents: [redTeam, target, evaluator],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -141,7 +141,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(securityTest);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents security_test_pipeline
+    // conductor deploy --package examples/agents/adk --agents security_test_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(securityTest);

--- a/examples/agents/adk/28-movie-pipeline.ts
+++ b/examples/agents/adk/28-movie-pipeline.ts
@@ -11,7 +11,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, FunctionTool } from '@google/adk';
@@ -191,7 +191,7 @@ export const moviePipeline = new SequentialAgent({
   subAgents: [conceptDeveloper, scriptwriter, visualDirector, audioDesigner, producer],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -208,7 +208,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(moviePipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents short_movie_pipeline
+    // conductor deploy --package examples/agents/adk --agents short_movie_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(moviePipeline);

--- a/examples/agents/adk/29-include-contents.ts
+++ b/examples/agents/adk/29-include-contents.ts
@@ -11,7 +11,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent } from '@google/adk';
@@ -51,7 +51,7 @@ export const coordinator = new LlmAgent({
   subAgents: [independentSummarizer, contextAwareHelper],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -69,7 +69,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(coordinator);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents coordinator
+    // conductor deploy --package examples/agents/adk --agents coordinator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(coordinator);

--- a/examples/agents/adk/30-thinking-config.ts
+++ b/examples/agents/adk/30-thinking-config.ts
@@ -10,7 +10,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -54,7 +54,7 @@ export const agent = new LlmAgent({
   },
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -71,7 +71,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents deep_thinker
+    // conductor deploy --package examples/agents/adk --agents deep_thinker
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/31-shared-state.ts
+++ b/examples/agents/adk/31-shared-state.ts
@@ -14,7 +14,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -73,7 +73,7 @@ export const agent = new LlmAgent({
   tools: [addItem, getList, clearList],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -89,7 +89,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents shopping_assistant
+    // conductor deploy --package examples/agents/adk --agents shopping_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/adk/32-nested-strategies.ts
+++ b/examples/agents/adk/32-nested-strategies.ts
@@ -14,7 +14,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, ParallelAgent, SequentialAgent } from '@google/adk';
@@ -63,7 +63,7 @@ export const pipeline = new SequentialAgent({
   subAgents: [parallelResearch, summarizer],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -79,7 +79,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents analysis_pipeline
+    // conductor deploy --package examples/agents/adk --agents analysis_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(pipeline);

--- a/examples/agents/adk/33-software-bug-assistant.ts
+++ b/examples/agents/adk/33-software-bug-assistant.ts
@@ -299,7 +299,7 @@ if (process.argv[1]?.endsWith('33-software-bug-assistant.ts') || process.argv[1]
       // 1. Deploy once during CI/CD:
       // await runtime.deploy(softwareAssistant);
       // CLI alternative:
-      // agentspan deploy --package sdk/typescript/examples/adk --agents software_assistant
+      // conductor deploy --package examples/agents/adk --agents software_assistant
       //
       // 2. In a separate long-lived worker process:
       // await runtime.serve(softwareAssistant);

--- a/examples/agents/adk/34-ml-engineering.ts
+++ b/examples/agents/adk/34-ml-engineering.ts
@@ -25,7 +25,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, SequentialAgent, ParallelAgent, LoopAgent } from '@google/adk';
@@ -173,7 +173,7 @@ export const mlPipeline = new SequentialAgent({
   subAgents: [dataAnalyst, parallelModeling, evaluator, refinementLoop, reporter],
 });
 
-// ── Run on agentspan ───────────────────────────────────────────────
+// ── Run on Conductor ───────────────────────────────────────────────
 
 async function main() {
   const runtime = new AgentRuntime();
@@ -192,7 +192,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(mlPipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents ml_pipeline
+    // conductor deploy --package examples/agents/adk --agents ml_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(mlPipeline);

--- a/examples/agents/adk/35-rag-agent.ts
+++ b/examples/agents/adk/35-rag-agent.ts
@@ -17,7 +17,7 @@
  *
  * Requirements:
  *   - npm install @google/adk zod
- *   - CONDUCTOR_SERVER_URL for agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { LlmAgent, FunctionTool } from '@google/adk';
@@ -253,7 +253,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(ragAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/adk --agents rag_assistant
+    // conductor deploy --package examples/agents/adk --agents rag_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(ragAgent);

--- a/examples/agents/dump-agent-configs.ts
+++ b/examples/agents/dump-agent-configs.ts
@@ -5,7 +5,7 @@
  * Writes each to _configs/{example_name}.json for cross-SDK comparison.
  *
  * Usage:
- *     cd sdk/typescript && npx tsx examples/dump-agent-configs.ts
+ *     npx tsx examples/agents/dump-agent-configs.ts
  */
 
 import { writeFileSync, mkdirSync } from 'fs';

--- a/examples/agents/kitchen-sink.ts
+++ b/examples/agents/kitchen-sink.ts
@@ -27,8 +27,8 @@
  *   mcp-testkit --transport http --auth <secret>
  *
  *   # Store credentials via CLI or Agentspan UI:
- *   agentspan credentials set MCP_AUTH_TOKEN <secret>
- *   agentspan credentials set SEARCH_API_KEY <key>
+ *   conductor secret put MCP_AUTH_TOKEN <secret>
+ *   conductor secret put SEARCH_API_KEY <key>
  *
  * Requirements:
  *   - Conductor server with LLM support
@@ -887,7 +887,7 @@ async function main() {
   // 1. Deploy once during CI/CD (optional -- serve() below also deploys):
   // await runtime.deploy(fullPipeline);
   // CLI alternative:
-  // agentspan deploy --package sdk/typescript/examples --agents content_publishing_platform
+  // conductor deploy --package examples/agents --agents content_publishing_platform
   //
   // 2. In a separate long-lived worker process (deploys + registers workers + starts polling):
   // await runtime.serve(fullPipeline);

--- a/examples/agents/langgraph/01-hello-world.ts
+++ b/examples/agents/langgraph/01-hello-world.ts
@@ -26,7 +26,7 @@ const graph = createReactAgent({ llm, tools: [], name: "hello_world_agent" });
 const PROMPT = 'Say hello and tell me a fun fact about Python programming.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -39,7 +39,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents hello_world
+    // conductor deploy --package examples/agents/langgraph --agents hello_world
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/02-react-with-tools.ts
+++ b/examples/agents/langgraph/02-react-with-tools.ts
@@ -77,7 +77,7 @@ const PROMPT =
   "What is the square root of 256? Also, how many words are in 'the quick brown fox'? And what is today's date?";
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -90,7 +90,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents react_with_tools
+    // conductor deploy --package examples/agents/langgraph --agents react_with_tools
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/03-memory.ts
+++ b/examples/agents/langgraph/03-memory.ts
@@ -27,7 +27,7 @@ const graph = createReactAgent({ llm, tools: [], checkpointer, name: "memory_age
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -44,7 +44,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents memory
+    // conductor deploy --package examples/agents/langgraph --agents memory
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/04-simple-stategraph.ts
+++ b/examples/agents/langgraph/04-simple-stategraph.ts
@@ -94,7 +94,7 @@ const graph = new StateGraph(QueryState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -107,7 +107,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents simple_stategraph
+    // conductor deploy --package examples/agents/langgraph --agents simple_stategraph
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/05-tool-node.ts
+++ b/examples/agents/langgraph/05-tool-node.ts
@@ -91,7 +91,7 @@ const graph = builder.compile({ name: "tool_node_agent" });
 const PROMPT = 'What is the capital and population of Japan and Brazil?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -104,7 +104,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents tool_node
+    // conductor deploy --package examples/agents/langgraph --agents tool_node
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/06-conditional-routing.ts
+++ b/examples/agents/langgraph/06-conditional-routing.ts
@@ -101,7 +101,7 @@ const graph = new StateGraph(SentimentState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -117,7 +117,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents conditional_routing
+    // conductor deploy --package examples/agents/langgraph --agents conditional_routing
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/07-system-prompt.ts
+++ b/examples/agents/langgraph/07-system-prompt.ts
@@ -50,7 +50,7 @@ const graph = createReactAgent({
 const PROMPT = 'I want to understand why 1 + 1 = 2. Can you just tell me?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -63,7 +63,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents system_prompt
+    // conductor deploy --package examples/agents/langgraph --agents system_prompt
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/08-structured-output.ts
+++ b/examples/agents/langgraph/08-structured-output.ts
@@ -45,7 +45,7 @@ const graph = createReactAgent({
 const PROMPT = 'Write a review for the movie Inception (2010).';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -58,7 +58,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents structured_output
+    // conductor deploy --package examples/agents/langgraph --agents structured_output
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/09-math-agent.ts
+++ b/examples/agents/langgraph/09-math-agent.ts
@@ -117,7 +117,7 @@ const PROMPT =
   'Calculate: (2^10 + sqrt(144)) / 4, then compute 5! and tell me the final answers.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -130,7 +130,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents math_agent
+    // conductor deploy --package examples/agents/langgraph --agents math_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/10-research-agent.ts
+++ b/examples/agents/langgraph/10-research-agent.ts
@@ -118,7 +118,7 @@ const PROMPT =
   'What are the latest developments in climate change research? Please search, summarize, and include citations.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -131,7 +131,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents research_agent
+    // conductor deploy --package examples/agents/langgraph --agents research_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/11-customer-support.ts
+++ b/examples/agents/langgraph/11-customer-support.ts
@@ -133,7 +133,7 @@ const PROMPT =
   'I was charged twice for my subscription this month and need a refund.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -146,7 +146,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents customer_support
+    // conductor deploy --package examples/agents/langgraph --agents customer_support
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/12-code-agent.ts
+++ b/examples/agents/langgraph/12-code-agent.ts
@@ -163,7 +163,7 @@ const PROMPT =
   'Write a binary search function in Python and explain how it works.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -176,7 +176,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents code_agent
+    // conductor deploy --package examples/agents/langgraph --agents code_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/13-multi-turn.ts
+++ b/examples/agents/langgraph/13-multi-turn.ts
@@ -37,7 +37,7 @@ const graph = createReactAgent({
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const SESSION_A = 'candidate-alice';
@@ -82,7 +82,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents multi_turn
+    // conductor deploy --package examples/agents/langgraph --agents multi_turn
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/14-qa-agent.ts
+++ b/examples/agents/langgraph/14-qa-agent.ts
@@ -109,7 +109,7 @@ const graph = new StateGraph(QAState)
 const PROMPT = 'What is Python and how many packages does it have?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -122,7 +122,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents qa_agent
+    // conductor deploy --package examples/agents/langgraph --agents qa_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/15-data-pipeline.ts
+++ b/examples/agents/langgraph/15-data-pipeline.ts
@@ -131,7 +131,7 @@ const graph = new StateGraph(PipelineState)
 const PROMPT = 'sales';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -144,7 +144,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents data_pipeline
+    // conductor deploy --package examples/agents/langgraph --agents data_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/16-parallel-branches.ts
+++ b/examples/agents/langgraph/16-parallel-branches.ts
@@ -108,7 +108,7 @@ const graph = new StateGraph(ParallelState)
 const PROMPT = 'remote work for software engineers';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -121,7 +121,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents parallel_branches
+    // conductor deploy --package examples/agents/langgraph --agents parallel_branches
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/17-error-recovery.ts
+++ b/examples/agents/langgraph/17-error-recovery.ts
@@ -109,7 +109,7 @@ const graph = new StateGraph(RecoveryState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -128,7 +128,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents error_recovery
+    // conductor deploy --package examples/agents/langgraph --agents error_recovery
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/18-tools-condition.ts
+++ b/examples/agents/langgraph/18-tools-condition.ts
@@ -86,7 +86,7 @@ const PROMPT =
   "What's the weather like in Tokyo and London? Also what timezone are they in?";
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -99,7 +99,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents tools_condition
+    // conductor deploy --package examples/agents/langgraph --agents tools_condition
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/19-document-analysis.ts
+++ b/examples/agents/langgraph/19-document-analysis.ts
@@ -209,7 +209,7 @@ const PROMPT =
   "Please provide a full analysis of the 'quarterly_report' document.";
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -222,7 +222,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents document_analysis
+    // conductor deploy --package examples/agents/langgraph --agents document_analysis
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/20-planner-agent.ts
+++ b/examples/agents/langgraph/20-planner-agent.ts
@@ -132,7 +132,7 @@ const PROMPT =
   'Launch a new open-source Python library for data validation.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -145,7 +145,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents planner_agent
+    // conductor deploy --package examples/agents/langgraph --agents planner_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/21-subgraph.ts
+++ b/examples/agents/langgraph/21-subgraph.ts
@@ -170,7 +170,7 @@ const PROMPT =
   'using simple Python functions.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -183,7 +183,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents subgraph
+    // conductor deploy --package examples/agents/langgraph --agents subgraph
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/22-human-in-the-loop.ts
+++ b/examples/agents/langgraph/22-human-in-the-loop.ts
@@ -130,7 +130,7 @@ const PROMPT =
   'Schedule a team meeting for next Monday at 10am to discuss Q3 plans.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -143,7 +143,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents human_in_the_loop
+    // conductor deploy --package examples/agents/langgraph --agents human_in_the_loop
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/23-retry-on-error.ts
+++ b/examples/agents/langgraph/23-retry-on-error.ts
@@ -119,7 +119,7 @@ const graph = new StateGraph(RetryState)
 const PROMPT = 'What is the speed of light in meters per second?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -132,7 +132,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents retry_on_error
+    // conductor deploy --package examples/agents/langgraph --agents retry_on_error
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/24-map-reduce.ts
+++ b/examples/agents/langgraph/24-map-reduce.ts
@@ -130,7 +130,7 @@ const graph = new StateGraph(OverallState)
 const PROMPT = 'renewable energy breakthroughs in 2024';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -143,7 +143,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents map_reduce
+    // conductor deploy --package examples/agents/langgraph --agents map_reduce
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/25-supervisor.ts
+++ b/examples/agents/langgraph/25-supervisor.ts
@@ -127,7 +127,7 @@ const graph = new StateGraph(SupervisorState)
 const PROMPT = 'The impact of large language models on software development';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -140,7 +140,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents supervisor
+    // conductor deploy --package examples/agents/langgraph --agents supervisor
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/26-agent-handoff.ts
+++ b/examples/agents/langgraph/26-agent-handoff.ts
@@ -120,7 +120,7 @@ const graph = new StateGraph(HandoffState)
 const PROMPT = 'I was charged twice for my subscription this month.';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -133,7 +133,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents agent_handoff
+    // conductor deploy --package examples/agents/langgraph --agents agent_handoff
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/27-persistent-memory.ts
+++ b/examples/agents/langgraph/27-persistent-memory.ts
@@ -79,7 +79,7 @@ const graph = new StateGraph(MemoryState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -103,7 +103,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents persistent_memory
+    // conductor deploy --package examples/agents/langgraph --agents persistent_memory
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/28-streaming-tokens.ts
+++ b/examples/agents/langgraph/28-streaming-tokens.ts
@@ -95,7 +95,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents streaming_tokens
+    // conductor deploy --package examples/agents/langgraph --agents streaming_tokens
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/29-tool-categories.ts
+++ b/examples/agents/langgraph/29-tool-categories.ts
@@ -176,7 +176,7 @@ const graph = createReactAgent({ llm, tools: allTools, name: "tool_categories_ag
 const PROMPT = 'What is the square root of 144?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -189,7 +189,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents tool_categories
+    // conductor deploy --package examples/agents/langgraph --agents tool_categories
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/30-code-interpreter.ts
+++ b/examples/agents/langgraph/30-code-interpreter.ts
@@ -118,7 +118,7 @@ const graph = createReactAgent({ llm, tools, name: "code_interpreter_agent" });
 const PROMPT = 'Calculate (2**10 - 1) * 3 + 7';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -131,7 +131,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents code_interpreter
+    // conductor deploy --package examples/agents/langgraph --agents code_interpreter
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/31-classify-and-route.ts
+++ b/examples/agents/langgraph/31-classify-and-route.ts
@@ -138,7 +138,7 @@ const graph = new StateGraph(ClassifyState)
 const PROMPT = 'What is photosynthesis?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -151,7 +151,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents classify_and_route
+    // conductor deploy --package examples/agents/langgraph --agents classify_and_route
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/32-reflection-agent.ts
+++ b/examples/agents/langgraph/32-reflection-agent.ts
@@ -121,7 +121,7 @@ const graph = new StateGraph(ReflectionState)
 const PROMPT = 'the importance of open-source software in modern technology';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -134,7 +134,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents reflection_agent
+    // conductor deploy --package examples/agents/langgraph --agents reflection_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/33-output-validator.ts
+++ b/examples/agents/langgraph/33-output-validator.ts
@@ -150,7 +150,7 @@ const graph = new StateGraph(ValidatorState)
 const PROMPT = 'Create a fictional software engineer from Japan';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -163,7 +163,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents output_validator
+    // conductor deploy --package examples/agents/langgraph --agents output_validator
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/34-rag-pipeline.ts
+++ b/examples/agents/langgraph/34-rag-pipeline.ts
@@ -195,7 +195,7 @@ const graph = new StateGraph(RAGState)
 const PROMPT = 'What is LangGraph and how does it differ from LangChain?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -208,7 +208,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents rag_pipeline
+    // conductor deploy --package examples/agents/langgraph --agents rag_pipeline
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/35-conversation-manager.ts
+++ b/examples/agents/langgraph/35-conversation-manager.ts
@@ -122,7 +122,7 @@ const graph = new StateGraph(ConversationState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const turns = [
@@ -146,7 +146,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents conversation_manager
+    // conductor deploy --package examples/agents/langgraph --agents conversation_manager
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/36-debate-agents.ts
+++ b/examples/agents/langgraph/36-debate-agents.ts
@@ -137,7 +137,7 @@ const graph = new StateGraph(DebateState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -153,7 +153,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents debate_agents
+    // conductor deploy --package examples/agents/langgraph --agents debate_agents
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/37-document-grader.ts
+++ b/examples/agents/langgraph/37-document-grader.ts
@@ -163,7 +163,7 @@ const graph = new StateGraph(GraderState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -179,7 +179,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents document_grader
+    // conductor deploy --package examples/agents/langgraph --agents document_grader
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/38-state-machine.ts
+++ b/examples/agents/langgraph/38-state-machine.ts
@@ -174,7 +174,7 @@ const graph = new StateGraph(OrderState)
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -199,7 +199,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents state_machine
+    // conductor deploy --package examples/agents/langgraph --agents state_machine
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/39-tool-call-chain.ts
+++ b/examples/agents/langgraph/39-tool-call-chain.ts
@@ -133,7 +133,7 @@ const graph = builder.compile({ name: "tool_call_chain_agent" });
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -146,7 +146,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents tool_call_chain
+    // conductor deploy --package examples/agents/langgraph --agents tool_call_chain
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/40-agent-as-tool.ts
+++ b/examples/agents/langgraph/40-agent-as-tool.ts
@@ -128,7 +128,7 @@ const graph = orchBuilder.compile({ name: "orchestrator_with_subagents" });
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const queries = [
@@ -149,7 +149,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents agent_as_tool
+    // conductor deploy --package examples/agents/langgraph --agents agent_as_tool
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/41-react-agent-basic.ts
+++ b/examples/agents/langgraph/41-react-agent-basic.ts
@@ -81,7 +81,7 @@ const PROMPT =
   "And what is 'Conductor' reversed?";
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -94,7 +94,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents react_agent_basic
+    // conductor deploy --package examples/agents/langgraph --agents react_agent_basic
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/42-react-agent-system-prompt.ts
+++ b/examples/agents/langgraph/42-react-agent-system-prompt.ts
@@ -97,7 +97,7 @@ const PROMPT =
   'How many yen will I get? The flight is 9,540 km — how far is that in miles?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -110,7 +110,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents react_agent_system_prompt
+    // conductor deploy --package examples/agents/langgraph --agents react_agent_system_prompt
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/43-react-agent-multi-model.ts
+++ b/examples/agents/langgraph/43-react-agent-multi-model.ts
@@ -85,7 +85,7 @@ const PROMPT =
   'What day of the week will that be?';
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   const runtime = new AgentRuntime();
@@ -98,7 +98,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents react_agent_multi_model
+    // conductor deploy --package examples/agents/langgraph --agents react_agent_multi_model
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/44-context-condensation.ts
+++ b/examples/agents/langgraph/44-context-condensation.ts
@@ -383,7 +383,7 @@ const graph = orchBuilder.compile({ name: "research_orchestrator" });
 };
 
 // ---------------------------------------------------------------------------
-// Run on agentspan
+// Run on Conductor
 // ---------------------------------------------------------------------------
 async function main() {
   console.log('Starting context condensation stress test (LangGraph / TypeScript).');
@@ -408,7 +408,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(graph);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents context_condensation
+    // conductor deploy --package examples/agents/langgraph --agents context_condensation
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(graph);

--- a/examples/agents/langgraph/45-advanced-orchestration.ts
+++ b/examples/agents/langgraph/45-advanced-orchestration.ts
@@ -232,7 +232,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agentRunnable);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/langgraph --agents advanced_orchestration
+    // conductor deploy --package examples/agents/langgraph --agents advanced_orchestration
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agentRunnable);

--- a/examples/agents/openai/01-basic-agent.ts
+++ b/examples/agents/openai/01-basic-agent.ts
@@ -9,7 +9,7 @@
  *   - Running it via Conductor passthrough (AgentRuntime)
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, setTracingDisabled } from '@openai/agents';
@@ -26,7 +26,7 @@ export const agent = new Agent({
 
 const prompt = 'Say hello and tell me a fun fact about the TypeScript programming language.';
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -38,7 +38,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents greeter
+    // conductor deploy --package examples/agents/openai --agents greeter
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/02-function-tools.ts
+++ b/examples/agents/openai/02-function-tools.ts
@@ -10,7 +10,7 @@
  *   - Running via Conductor passthrough
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, tool, setTracingDisabled } from '@openai/agents';
@@ -82,7 +82,7 @@ const prompt =
   "What's the weather in San Francisco? Also, what's the population there " +
   "and what's the square root of that number (just the digits)?";
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -94,7 +94,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents multi_tool_agent
+    // conductor deploy --package examples/agents/openai --agents multi_tool_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/03-structured-output.ts
+++ b/examples/agents/openai/03-structured-output.ts
@@ -10,7 +10,7 @@
  *   - Model settings (temperature) for deterministic output
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, setTracingDisabled } from '@openai/agents';
@@ -51,7 +51,7 @@ export const agent = new Agent({
 
 const prompt = 'Recommend 3 sci-fi movies that explore the concept of artificial intelligence.';
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -63,7 +63,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents movie_recommender
+    // conductor deploy --package examples/agents/openai --agents movie_recommender
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/04-handoffs.ts
+++ b/examples/agents/openai/04-handoffs.ts
@@ -10,7 +10,7 @@
  *   - Running via Conductor passthrough
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, tool, setTracingDisabled } from '@openai/agents';
@@ -107,7 +107,7 @@ export const triageAgent = new Agent({
 
 const prompt = "I'd like a refund for order ORD-002, the product arrived damaged.";
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -119,7 +119,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(triageAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents customer_service_triage
+    // conductor deploy --package examples/agents/openai --agents customer_service_triage
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(triageAgent);

--- a/examples/agents/openai/05-guardrails.ts
+++ b/examples/agents/openai/05-guardrails.ts
@@ -10,7 +10,7 @@
  *   - Running via Conductor passthrough
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import {
@@ -126,7 +126,7 @@ export const agent = new Agent({
   outputGuardrails: [checkOutputSafety],
 });
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -138,7 +138,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents banking_assistant
+    // conductor deploy --package examples/agents/openai --agents banking_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/06-model-settings.ts
+++ b/examples/agents/openai/06-model-settings.ts
@@ -10,7 +10,7 @@
  *   - High temperature for creative responses
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, setTracingDisabled } from '@openai/agents';
@@ -46,7 +46,7 @@ export const preciseAgent = new Agent({
   },
 });
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -70,7 +70,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(creativeAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents creative_writer
+    // conductor deploy --package examples/agents/openai --agents creative_writer
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(creativeAgent);

--- a/examples/agents/openai/07-streaming.ts
+++ b/examples/agents/openai/07-streaming.ts
@@ -9,7 +9,7 @@
  *   - Running via Conductor passthrough
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import {
@@ -58,7 +58,7 @@ export const agent = new Agent({
 
 const prompt = "What's your return policy for electronics?";
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -69,7 +69,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents support_agent
+    // conductor deploy --package examples/agents/openai --agents support_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/08-agent-as-tool.ts
+++ b/examples/agents/openai/08-agent-as-tool.ts
@@ -10,7 +10,7 @@
  *   - Differs from handoffs: manager retains control and synthesizes results
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, tool, setTracingDisabled } from '@openai/agents';
@@ -107,7 +107,7 @@ const prompt =
   "and the battery life is wonderful. However, the keyboard feels terrible " +
   "and the trackpad is the worst I've used.'";
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -119,7 +119,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(manager);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents text_analysis_manager
+    // conductor deploy --package examples/agents/openai --agents text_analysis_manager
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(manager);

--- a/examples/agents/openai/09-dynamic-instructions.ts
+++ b/examples/agents/openai/09-dynamic-instructions.ts
@@ -10,7 +10,7 @@
  *   - Function tools alongside dynamic instructions
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, tool, setTracingDisabled } from '@openai/agents';
@@ -91,7 +91,7 @@ export const agent = new Agent({
 
 const prompt = "Show me my todo list and add 'Prepare demo for Friday' as high priority.";
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -103,7 +103,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents personal_assistant
+    // conductor deploy --package examples/agents/openai --agents personal_assistant
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/openai/10-multi-model.ts
+++ b/examples/agents/openai/10-multi-model.ts
@@ -10,7 +10,7 @@
  *   - Model override for cost/performance optimization
  *
  * Requirements:
- *   - CONDUCTOR_SERVER_URL for the Agentspan path
+ *   - CONDUCTOR_SERVER_URL=http://localhost:8080/api
  */
 
 import { Agent, tool, setTracingDisabled } from '@openai/agents';
@@ -110,7 +110,7 @@ triage.handoffs = [docSpecialist, codeSpecialist];
 
 const prompt = 'I need a Python code example for authenticating with the API.';
 
-// ── Run on agentspan ──────────────────────────────────────────────
+// ── Run on Conductor ──────────────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -122,7 +122,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(triage);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/openai --agents triage
+    // conductor deploy --package examples/agents/openai --agents triage
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(triage);

--- a/examples/agents/quickstart/01-basic-agent.ts
+++ b/examples/agents/quickstart/01-basic-agent.ts
@@ -21,7 +21,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/quickstart --agents greeter
+    // conductor deploy --package examples/agents/quickstart --agents greeter
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/quickstart/02-tools.ts
+++ b/examples/agents/quickstart/02-tools.ts
@@ -36,7 +36,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/quickstart --agents weather_bot
+    // conductor deploy --package examples/agents/quickstart --agents weather_bot
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/quickstart/03-multi-agent.ts
+++ b/examples/agents/quickstart/03-multi-agent.ts
@@ -29,7 +29,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(pipeline);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/quickstart --agents researcher
+    // conductor deploy --package examples/agents/quickstart --agents researcher
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(pipeline);

--- a/examples/agents/quickstart/04-guardrails.ts
+++ b/examples/agents/quickstart/04-guardrails.ts
@@ -30,7 +30,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/quickstart --agents safe_bot
+    // conductor deploy --package examples/agents/quickstart --agents safe_bot
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/quickstart/05-claude-code.ts
+++ b/examples/agents/quickstart/05-claude-code.ts
@@ -22,7 +22,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/quickstart --agents code_explorer
+    // conductor deploy --package examples/agents/quickstart --agents code_explorer
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/01-basic-agent.ts
+++ b/examples/agents/vercel-ai/01-basic-agent.ts
@@ -33,7 +33,7 @@ export const agent = new Agent({
 
 const prompt = 'What is the weather in San Francisco?';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -45,7 +45,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents weather_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents weather_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/02-tools-compat.ts
+++ b/examples/agents/vercel-ai/02-tools-compat.ts
@@ -55,7 +55,7 @@ export const agent = new Agent({
 
 const prompt = 'Search for quantum computing and also calculate 2 + 2.';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -67,7 +67,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents mixed_tools_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents mixed_tools_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/03-streaming.ts
+++ b/examples/agents/vercel-ai/03-streaming.ts
@@ -42,7 +42,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents streaming_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents streaming_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/04-structured-output.ts
+++ b/examples/agents/vercel-ai/04-structured-output.ts
@@ -29,7 +29,7 @@ export const agent = new Agent({
 
 const prompt = 'Generate a profile for a fictional ML engineer from Japan.';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -49,7 +49,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents structured_output_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents structured_output_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/05-multi-step.ts
+++ b/examples/agents/vercel-ai/05-multi-step.ts
@@ -56,7 +56,7 @@ export const agent = new Agent({
 
 const prompt = 'What is the current weather and time in San Francisco and Tokyo?';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -69,7 +69,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents multistep_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents multistep_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/06-middleware.ts
+++ b/examples/agents/vercel-ai/06-middleware.ts
@@ -73,7 +73,7 @@ export const agent = new Agent({
   guardrails: [piiGuardrail, outputLogGuardrail],
 });
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -92,7 +92,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents guarded_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents guarded_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/07-stop-conditions.ts
+++ b/examples/agents/vercel-ai/07-stop-conditions.ts
@@ -66,7 +66,7 @@ export const agent = new Agent({
 const prompt =
   'Analyze market trends for AI infrastructure companies. Look at revenue growth, adoption rates, and competitive landscape, then summarize.';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   analysisStepCount = 0;
   const runtime = new AgentRuntime();
@@ -80,7 +80,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents stop_conditions_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents stop_conditions_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/08-agent-handoff.ts
+++ b/examples/agents/vercel-ai/08-agent-handoff.ts
@@ -73,7 +73,7 @@ const queries = [
   'What is the weather like today?',
 ];
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -89,7 +89,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(triageAgent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents triage_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents triage_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(triageAgent);

--- a/examples/agents/vercel-ai/09-credentials.ts
+++ b/examples/agents/vercel-ai/09-credentials.ts
@@ -45,7 +45,7 @@ export const agent = new Agent({
 
 const prompt = 'Fetch the analytics report with ID RPT-2024-Q4.';
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 async function main() {
   const runtime = new AgentRuntime();
   try {
@@ -57,7 +57,7 @@ async function main() {
     // 1. Deploy once during CI/CD:
     // await runtime.deploy(agent);
     // CLI alternative:
-    // agentspan deploy --package sdk/typescript/examples/vercel-ai --agents credentialed_agent
+    // conductor deploy --package examples/agents/vercel-ai --agents credentialed_agent
     //
     // 2. In a separate long-lived worker process:
     // await runtime.serve(agent);

--- a/examples/agents/vercel-ai/10-hitl.ts
+++ b/examples/agents/vercel-ai/10-hitl.ts
@@ -92,7 +92,7 @@ async function promptHuman(
   return response;
 }
 
-// ── Run on agentspan ─────────────────────────────────────
+// ── Run on Conductor ─────────────────────────────────────
 
 const rl = readline.createInterface({ input: stdin, output: stdout });
 const runtime = new AgentRuntime();


### PR DESCRIPTION
The agentspan CLI was folded into the conductor CLI in conductor-oss/conductor-cli#89. The examples still documented the retired binary, and their `--package` paths pointed at the pre-port monorepo layout (`sdk/typescript/examples`) — so none of the commented deploy commands worked as written.

Mapping, verified against `conductor-cli` `origin/main`:

| agentspan | conductor | n |
|---|---|---|
| `deploy --package sdk/typescript/examples[/<fw>]` | `deploy --package examples/agents[/<fw>]` | 196 |
| `credentials set <k> <v>` | `secret put <k> <v>` | 31 |
| `login` | `config save` | 3 |
| `run <name> "prompt"` | `agent run --name <name> "prompt"` | 1 |

Also: `Run on agentspan` → `Run on Conductor` (96, padding unchanged — both 9 chars); `CONDUCTOR_SERVER_URL for [the] agentspan path` → the house-style line (45, the qualifier implied a non-Conductor path that no example offers); and two stale `sdk/typescript` paths.

`tsc --noEmit`: 285 errors, unchanged from baseline.
