### PR TITLE
docs: remove stale Agentspan product references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ src/agents/                      # Durable agent layer (merged from the standalo
   wrappers/                      # Vercel AI / LangGraph / LangChain drop-in wrappers
   __tests__/                     # Colocated jest unit tests (picked up by test:unit)
 e2e/                             # Agent e2e suites vs a live Conductor server (jest.e2e.config.mjs)
-cli-bin/                         # agentspan CLI helper scripts (Go CLI walk-up probe target)
+cli-bin/                         # Conductor CLI helper scripts (Go CLI walk-up probe target)
 examples/agents/                 # Agent examples (own tsconfig; run via npx tsx)
 docs/agents/                     # Agent layer documentation
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig(
     },
   },
   {
-    // src/agents is the Agentspan agent SDK merged in-tree. Its framework
+    // src/agents is the Conductor agent SDK merged in-tree. Its framework
     // serializers walk arbitrary langgraph/langchain object graphs, so it keeps
     // the upstream lint contract for these two rules (upstream pins both to
     // "warn" in its eslint config); everything else lints at this repo's level.

--- a/examples/agents/adk/README.md
+++ b/examples/agents/adk/README.md
@@ -54,7 +54,7 @@ import { LlmAgent, FunctionTool }
   from '@google/adk';
 import { z } from 'zod';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
-// ^^^ add agentspan import
+// ^^^ add Conductor agent import
 
 const getWeather = new FunctionTool({
   name: 'get_weather',

--- a/examples/agents/langgraph/README.md
+++ b/examples/agents/langgraph/README.md
@@ -1,6 +1,6 @@
 # LangGraph + Conductor Agent
 
-Keep your existing LangGraph code. Add agentspan metadata and run with `runtime.run()`.
+Keep your existing LangGraph code. Attach Conductor metadata and run with `runtime.run()`.
 
 ## createReactAgent
 
@@ -60,7 +60,7 @@ import { DynamicStructuredTool }
   from '@langchain/core/tools';
 import { z } from 'zod';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
-// ^^^ add agentspan import
+// ^^^ add Conductor agent import
 
 const llm = new ChatOpenAI({
   model: 'gpt-4o-mini',
@@ -82,7 +82,7 @@ const graph = createReactAgent({
   tools: [calculate],
 });
 
-// Add agentspan metadata
+// Attach Conductor metadata
 (graph as any)._agentspan = {
   model: 'anthropic/claude-sonnet-4-6',
   tools: [calculate],
@@ -106,7 +106,7 @@ await runtime.shutdown();
 Same pattern — build the graph normally, attach metadata, run with `runtime.run()`.
 
 <table>
-<tr><th>Before (vanilla LangGraph)</th><th>After (Agentspan)</th></tr>
+<tr><th>Before (vanilla LangGraph)</th><th>After (Conductor Agent)</th></tr>
 <tr><td>
 
 ```typescript
@@ -144,7 +144,7 @@ import { StateGraph, Annotation,
   START, END }
   from '@langchain/langgraph';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
-// ^^^ add agentspan import
+// ^^^ add Conductor agent import
 
 const State = Annotation.Root({
   input: Annotation<string>(),
@@ -159,7 +159,7 @@ const graph = new StateGraph(State)
   .addEdge('process', END)
   .compile();
 
-// Add agentspan metadata
+// Attach Conductor metadata
 (graph as any)._agentspan = {
   model: 'anthropic/claude-sonnet-4-6',
   tools: [],

--- a/examples/agents/openai/README.md
+++ b/examples/agents/openai/README.md
@@ -48,7 +48,7 @@ import { Agent, tool, setTracingDisabled }
 // ^^^ replace run() with setTracingDisabled
 import { z } from 'zod';
 import { AgentRuntime } from '@io-orkes/conductor-javascript/agents';
-// ^^^ add agentspan import
+// ^^^ add Conductor agent import
 
 const getWeather = tool({
   name: 'get_weather',

--- a/examples/agents/vercel-ai/README.md
+++ b/examples/agents/vercel-ai/README.md
@@ -65,7 +65,7 @@ console.log(result.text);
 </td></tr>
 </table>
 
-Everything else — tools, model, prompt, result shape — is unchanged. Under the hood, `generateText` builds a Agentspan `Agent`, runs it on the platform, and maps the result back to the AI SDK format.
+Everything else — tools, model, prompt, result shape — is unchanged. Under the hood, `generateText` builds a Conductor `Agent`, runs it on the platform, and maps the result back to the AI SDK format.
 
 ## Production: Agent API
 
@@ -110,7 +110,7 @@ import { tool as aiTool } from 'ai';
 import { z } from 'zod';
 import { Agent, AgentRuntime } from '@io-orkes/conductor-javascript/agents';
 //      ^^^^^  ^^^^^^^^^^^^
-//      agentspan Agent + Runtime
+//      Conductor Agent + Runtime
 
 const weatherTool = aiTool({
   description: 'Get weather for a city',


### PR DESCRIPTION
## Summary

- replace stale Agentspan product-name references in the four agent example READMEs with Conductor terminology
- align the related repository-layout and lint comments
- preserve the `_agentspan` metadata property because it remains part of the serializer contract

Fixes #173.

## Before / after evidence

The issue's user-facing scope contained 12 stale product-name references on `main`:

```text
upstream/main:AGENTS.md:50:cli-bin/                         # agentspan CLI helper scripts (Go CLI walk-up probe target)
upstream/main:eslint.config.mjs:31:    // src/agents is the Agentspan agent SDK merged in-tree. Its framework
upstream/main:examples/agents/adk/README.md:57:// ^^^ add agentspan import
upstream/main:examples/agents/langgraph/README.md:3:Keep your existing LangGraph code. Add agentspan metadata and run with `runtime.run()`.
upstream/main:examples/agents/langgraph/README.md:63:// ^^^ add agentspan import
upstream/main:examples/agents/langgraph/README.md:85:// Add agentspan metadata
upstream/main:examples/agents/langgraph/README.md:109:<tr><th>Before (vanilla LangGraph)</th><th>After (Agentspan)</th></tr>
upstream/main:examples/agents/langgraph/README.md:147:// ^^^ add agentspan import
upstream/main:examples/agents/langgraph/README.md:162:// Add agentspan metadata
upstream/main:examples/agents/openai/README.md:51:// ^^^ add agentspan import
upstream/main:examples/agents/vercel-ai/README.md:68:Everything else — tools, model, prompt, result shape — is unchanged. Under the hood, `generateText` builds a Agentspan `Agent`, runs it on the platform, and maps the result back to the AI SDK format.
upstream/main:examples/agents/vercel-ai/README.md:113://      agentspan Agent + Runtime
```

The same check at `1e45956` returns no matches:

```text
$ rg -ni --pcre2 '(?<!_)agentspan' examples/agents/langgraph/README.md examples/agents/vercel-ai/README.md examples/agents/adk/README.md examples/agents/openai/README.md AGENTS.md eslint.config.mjs
(no output)
```

## Verification

```text
$ npm run lint
0 errors (existing warnings only)

$ npm run test:unit
Test Suites: 79 passed, 79 total
Tests:       1567 passed, 1567 total
Snapshots:   0 total

$ git diff --check
(no output)
```

The live-server examples were not run because they require a Conductor server and external credentials; this change only updates documentation and comments.
