### PR TITLE
test(integration): tolerate a slow server in three latency-sensitive suites

### DIFF
--- a/src/integration-tests/LeaseExtension.validation.test.ts
+++ b/src/integration-tests/LeaseExtension.validation.test.ts
@@ -47,6 +47,9 @@ import { cleanupWorkflowsAndTasks } from "./utils/cleanup";
 // ─── Timing constants ────────────────────────────────────────────────────────
 const RESPONSE_TIMEOUT_SECONDS = 10;          // responseTimeoutSeconds on task def
 const TASK_EXECUTION_MS        = 20_000;       // worker "works" for 20s (> 10s timeout)
+// Long-poll window. The task is polled immediately after startWorkflow, so
+// this has to cover the server's queueing latency, not just the network hop.
+const POLL_WAIT_MS             = 5_000;
 // Heartbeat fires at 10 * 0.8 = 8s — before the 10s deadline
 
 describe("Lease Extension — end-to-end validation", () => {
@@ -127,7 +130,7 @@ describe("Lease Extension — end-to-end validation", () => {
     console.log(`\n▶  Workflow 1  id=${workflowId1}  (no heartbeat)`);
 
     // Poll the task directly so we control execution
-    const { data: tasks1 } = await TaskResource.batchPoll({ client, path: { tasktype: taskDefName }, query: { workerid: "val-worker-no-lease", count: 1, timeout: 200 } });
+    const { data: tasks1 } = await TaskResource.batchPoll({ client, path: { tasktype: taskDefName }, query: { workerid: "val-worker-no-lease", count: 1, timeout: POLL_WAIT_MS } });
     const [task] = tasks1 ?? [];
     expect(task).toBeDefined();
     const taskId1 = task.taskId ?? "";
@@ -172,7 +175,7 @@ describe("Lease Extension — end-to-end validation", () => {
     const workflowId2 = await executor.startWorkflowByName(wfName, {}, 1);
     console.log(`\n▶  Workflow 2  id=${workflowId2}  (with heartbeat)`);
 
-    const { data: tasks2 } = await TaskResource.batchPoll({ client, path: { tasktype: taskDefName }, query: { workerid: "val-worker-with-lease", count: 1, timeout: 200 } });
+    const { data: tasks2 } = await TaskResource.batchPoll({ client, path: { tasktype: taskDefName }, query: { workerid: "val-worker-with-lease", count: 1, timeout: POLL_WAIT_MS } });
     const [task] = tasks2 ?? [];
     expect(task).toBeDefined();
     const taskId2 = task.taskId ?? "";

--- a/src/integration-tests/TaskManager.test.ts
+++ b/src/integration-tests/TaskManager.test.ts
@@ -13,13 +13,17 @@ import { waitForWorkflowCompletion } from "./utils/waitForWorkflowCompletion";
 import { describeForOrkesV5 } from "./utils/customJestDescribe";
 
 const BASE_TIME = 1000;
+// Every other integration test takes waitForWorkflowCompletion's 5-minute
+// default. These four wait on a worker to poll for and finish each task, so
+// they need enough room for a slow or contended server; 30s was losing races.
+const WF_WAIT_MS = BASE_TIME * 90;
 describe("TaskManager", () => {
   const clientPromise = createClientWithRetry();
   const workflowsToCleanup: { name: string; version: number }[] = [];
   const tasksToCleanup: string[] = [];
   const activeManagers: TaskManager[] = [];
 
-  jest.setTimeout(60000);
+  jest.setTimeout(120000);
 
   afterEach(async () => {
     for (const m of activeManagers) {
@@ -136,7 +140,7 @@ describe("TaskManager", () => {
     const workflowStatus = await waitForWorkflowCompletion(
       executor,
       executionId,
-      BASE_TIME * 30
+      WF_WAIT_MS
     );
 
     expect(workflowStatus.status).toEqual("COMPLETED");
@@ -211,7 +215,7 @@ describe("TaskManager", () => {
     const workflowStatus = await waitForWorkflowCompletion(
       executor,
       status,
-      BASE_TIME * 30
+      WF_WAIT_MS
     );
 
     expect(workflowStatus.status).toEqual("FAILED");
@@ -283,7 +287,7 @@ describe("TaskManager", () => {
     const workflowStatus = await waitForWorkflowCompletion(
       executor,
       executionId,
-      BASE_TIME * 30
+      WF_WAIT_MS
     );
     expect(workflowStatus.status).toEqual("FAILED");
     await manager.stopPolling();
@@ -358,7 +362,7 @@ describe("TaskManager", () => {
     const workflowStatus = await waitForWorkflowCompletion(
       executor,
       executionId,
-      BASE_TIME * 30
+      WF_WAIT_MS
     );
 
     expect(workflowStatus.status).toEqual("COMPLETED");

--- a/src/integration-tests/WorkflowExecutor.test.ts
+++ b/src/integration-tests/WorkflowExecutor.test.ts
@@ -353,7 +353,9 @@ describe("WorkflowExecutor", () => {
 
       // Register all test workflows
       await registerAllWorkflows();
-    }, 30000);
+      // No explicit hook timeout: inherit the describe's 300s. Registering
+      // several workflow definitions against a slow server outran 30s.
+    });
 
     afterEach(async () => {
       // Clean up executions first


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

## Summary

- Three integration suites fail intermittently against sdkdev with timeouts and empty polls rather than assertion failures: `WorkflowExecutor.test.ts` (the whole file), `LeaseExtension.validation.test.ts` and `TaskManager.test.ts`.
- Three distinct causes, all budgets too tight to absorb server latency. `WorkflowExecutor`'s `beforeAll` passed an explicit `30000` that overrode its own describe's `jest.setTimeout(300000)`, and a dead hook fails every test in the file. Both `LeaseExtension` tests `batchPoll` with a 200ms long-poll window immediately after `startWorkflow`, so a queue slower than that yields no task. `TaskManager`'s four waits were the only overrides of `waitForWorkflowCompletion`'s 5-minute default, at 30s.
- Fix: inherit the describe's timeout, widen the poll window to 5s, raise the four waits to 90s and the file's jest timeout to 120s.

## User impact

Shard 3/3 has lost a rotating test since mid-August, on `main` and on unrelated branches. Once #176 gated `REGION_DURABLE`, these became the visible failure and took `WorkflowExecutor`'s `SYNC` cases down with them, since one expired hook fails every test in its file.

## Changes

- `WorkflowExecutor.test.ts`: drop the `beforeAll` timeout override so it inherits the describe's 300s.
- `LeaseExtension.validation.test.ts`: `batchPoll` window 200ms to 5s, named `POLL_WAIT_MS`. The 20s execution and heartbeat behaviour under test is unchanged.
- `TaskManager.test.ts`: four waits to 90s via `WF_WAIT_MS`, jest timeout to 120s, matching `WorkerAdvanced.test.ts`.

## Test plan

- Cherry-picked onto another branch to exercise CI: every `integration v5 sdkdev` shard passed on Node 20, 22 and 24, against the same server that had been failing them.
- Locally against Conductor 3.32.0: `TaskManager` and `LeaseExtension` pass, and `WorkflowExecutor` gets past the hook that was expiring.
